### PR TITLE
Add linter, formatter, and pre-commit hooks to project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ on:
       - main
       - staging
       - dev
+    paths:
+      - '**.py'
   pull_request:
-    branches:
-      - main
-      - staging
-      - dev
+    paths:
+      - '**.py'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ GitHub.sublime-settings
 !.vscode/launch.json
 !.vscode/extensions.json
 .history
+
+# Ruff
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     -   id: ruff
         args:
         - --fix
+        - --config ./ruff.toml
     -   id: ruff-format
 -   repo: https://github.com/trufflesecurity/trufflehog
     rev: v3.88.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.7
+    hooks:
+    -   id: ruff
+        args:
+        - --fix
+    -   id: ruff-format
+-   repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.88.13
+    hooks:
+    -   id: trufflehog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: ruff
         args:
         - --fix
-        - --config ./ruff.toml
+        - --config=./ruff.toml
     -   id: ruff-format
 -   repo: https://github.com/trufflesecurity/trufflehog
     rev: v3.88.13

--- a/app/element_objects.py
+++ b/app/element_objects.py
@@ -1,66 +1,71 @@
-class ClassObject():
+from __future__ import annotations
 
+
+class ClassObject:
     def __init__(self):
         self.__name: str = ""
         self.__parent: ClassObject = None
-        self.__fields : list[FieldObject] = []
-        self.__methods : list[ClassMethodObject] = []
-        self.__relationships : list[AbstractRelationshipObject] = []
-        
-
+        self.__fields: list[FieldObject] = []
+        self.__methods: list[ClassMethodObject] = []
+        self.__relationships: list[AbstractRelationshipObject] = []
 
     def __str__(self) -> str:
-        return f'''Class Object:\n\tname: {self.__name}\n\tparent: {self.__parent}\n\tfields:{self.__fields}\n\t \
-methods: {self.__methods}\n\trelationships: {self.__relationships}'''
-    
-    def set_name(self, name):
+        return (
+            f"Class Object:\n\tname: {self.__name}\n\tparent: {self.__parent}"
+            f"\n\tfields:{self.__fields}\n\t methods: {self.__methods}"
+            f"\n\trelationships: {self.__relationships}"
+        )
+
+    def set_name(self, name: str):
         self.__name = name
-    
-    def set_parent(self, parent):
+
+    def set_parent(self, parent: ClassObject):
         self.__parent = parent
 
-    def add_field(self, field):
+    def add_field(self, field: FieldObject):
         self.__fields.append(field)
-    
-    def add_method(self, method):
+
+    def add_method(self, method: ClassMethodObject):
         self.__methods.append(method)
 
-    def add_relationship(self, relationship):
+    def add_relationship(self, relationship: AbstractRelationshipObject):
         self.__relationships.append(relationship)
 
 
-class FieldObject():
-    
+class FieldObject:
     def __init__(self):
-        self.__name : str = ""
-        self.__type : TypeObject = None
+        self.__name: str = ""
+        self.__type: TypeObject = None
 
-    def __str__(self):
-        return f'''FieldObject:\n\tname: {self.__name}\n\ttype: {self.__type}'''
-    
-    def set_name(self, name):
+    def __str__(self) -> str:
+        return f"""FieldObject:\n\tname: {self.__name}\n\ttype: {self.__type}"""
+
+    def set_name(self, name: str):
         self.__name = name
-    
-    def set_type(self, type):
+
+    def set_type(self, type: TypeObject):
         self.__type = type
 
 
-class AbstractMethodObject():
+class AbstractMethodObject:
     def __init__(self):
-        self.__name : str = ""
-        self.__parameters : list[ParameterObject] = []
-        self.__returnType : TypeObject = None
+        self.__name: str = ""
+        self.__parameters: list[ParameterObject] = []
+        self.__returnType: TypeObject = None
 
-    def __str__(self):
-        return f'''MethodObject:\n\tname: {self.__name}\n\tparameters: {self.__parameters}\n\treturnType: {self.__returnType}'''
-    
-    def set_name(self, name):
+    def __str__(self) -> str:
+        return (
+            f"MethodObject:\n\tname: {self.__name}\n\tparameters: {self.__parameters}"
+            f"\n\treturnType: {self.__returnType}"
+        )
+
+    def set_name(self, name: str):
         self.__name = name
 
-    def add_parameter(self, parameter):
+    def add_parameter(self, parameter: ParameterObject):
         self.__parameters.append(parameter)
 
-    def set_returnType(self, returnType):
+    def set_returnType(self, returnType: TypeObject):
         self.__returnType = returnType
 
 
@@ -68,88 +73,100 @@ class ClassMethodObject(AbstractMethodObject):
     def __init__(self):
         super().__init__()
         self.__calls: list[ClassMethodCallObject] = []
-    
-    def add_class_method_call(self, class_method_call):
-        if class_method_call == None:
+
+    def add_class_method_call(self, class_method_call: ClassMethodCallObject):
+        if class_method_call is None:
             raise Exception("Cannot add None to ClassMethodCallObject!")
         self.__calls.append(class_method_call)
 
-class AbstractRelationshipObject():
+
+class AbstractRelationshipObject:
     def __init__(self):
         self.__sourceClass: ClassObject = None
         self.__targetClass: ClassObject = None
-    
-    def setSourceClass(self, sourceClass):
-        if sourceClass == None:
+
+    def setSourceClass(self, sourceClass: ClassObject):
+        if sourceClass is None:
             raise Exception("Source Class cannot be SET to be None!")
         self.__sourceClass = sourceClass
-    
-    def setTargetClass(self, targetClass):
-        if targetClass == None:
+
+    def setTargetClass(self, targetClass: ClassObject):
+        if targetClass is None:
             raise Exception("Target Class cannot be SET to be None!")
         self.__targetClass = targetClass
 
-class TypeObject():
+
+class TypeObject:
     def __init__(self):
         self.__name = ""
-    
-    def set_name(self, name):
-        self.__name = name
-        
 
-class ParameterObject():
+    def set_name(self, name: str):
+        self.__name = name
+
+
+class ParameterObject:
     def __init__(self):
         self.__name: str = ""
         self.__type: TypeObject = None
 
-    def __str__(self):
-        return f'''ParameterObject:\n\tname: {self.__name}\n\ttype: {self.__type}'''
-    
-    def set_name(self, name):
+    def __str__(self) -> str:
+        return f"""ParameterObject:\n\tname: {self.__name}\n\ttype: {self.__type}"""
+
+    def set_name(self, name: str):
         self.__name = name
-    
-    def set_type(self, type):
+
+    def set_type(self, type: str):
         self.__type = type
 
-class AbstractMethodCallObject():
+
+class AbstractMethodCallObject:
     def __init__(self):
         self.__method: AbstractMethodObject = None
         self.__arguments: list[ArgumentObject] = []
         self.__returnVarName: str = ""
 
-    def __str__(self):
-        return f'''MethodCallObject:\n\tmethod: {self.__method}\n\targuments: {self.__arguments}\n\treturnVarName: {self.__returnVarName}'''
-    
-    def set_method(self, method):
+    def __str__(self) -> str:
+        return (
+            f"MethodCallObject:\n\tmethod: {self.__method}\n\t"
+            f"arguments: {self.__arguments}\n\treturnVarName: {self.__returnVarName}"
+        )
+
+    def set_method(self, method: AbstractMethodObject):
         self.__method = method
 
-    def add_argument(self, argument):
+    def add_argument(self, argument: ArgumentObject):
         self.__arguments.append(argument)
 
-    def set_returnVarName(self, returnVarName):
+    def set_returnVarName(self, returnVarName: str):
         self.__returnVarName = returnVarName
 
-class ArgumentObject():
+
+class ArgumentObject:
     def __init__(self):
         self.__methodObject: AbstractMethodCallObject = None
         self.__name: str = ""
         self.__type: TypeObject = None
-    
-    def __str__(self):
-        return f'''ArgumentObject:\n\tmethodObject: \n\t[{self.__methodObject}]\n\tname: {self.__name}\n\ttype: \n\t[{self.__type}]'''
-    
-    def set_methodObject(self, methodObject):
+
+    def __str__(self) -> str:
+        return (
+            f"ArgumentObject:\n\tmethodObject: \n\t[{self.__methodObject}]"
+            f"\n\tname: {self.__name}\n\ttype: \n\t[{self.__type}]"
+        )
+
+    def set_methodObject(self, methodObject: AbstractMethodCallObject):
         self.__methodObject = methodObject
 
-    def set_name(self, name):
+    def set_name(self, name: str):
         self.__name = name
 
-    def set_type(self, type):
+    def set_type(self, type: TypeObject):
         self.__type = type
+
 
 class OneToOneRelationshipObject(AbstractRelationshipObject):
     def __init__(self):
         super().__init__()
+
 
 class ManyToOneRelationshipObject(AbstractRelationshipObject):
     def __init__(self):
@@ -164,25 +181,27 @@ class ManyToManyRelationshipObject(AbstractRelationshipObject):
 class ControllerMethodCallObject(AbstractMethodCallObject):
     def __init__(self):
         super().__init__()
-        self.__caller : ClassMethodObject = None
+        self.__caller: ClassMethodObject = None
 
-    def set_caller(self, caller : ClassMethodObject):
+    def set_caller(self, caller: ClassMethodObject):
         self.__caller = caller
+
 
 class ControllerMethodObject(AbstractMethodObject):
     def __init__(self):
         super().__init__()
-        self.__calls : list[AbstractMethodCallObject] = []
-    
-    def add_calls(self, call_object : AbstractMethodCallObject):
+        self.__calls: list[AbstractMethodCallObject] = []
+
+    def add_calls(self, call_object: AbstractMethodCallObject):
         self.__calls.append(call_object)
+
 
 class ClassMethodCallObject(AbstractMethodCallObject):
     def __init__(self):
         super().__init__()
         self.__caller: ClassMethodObject = None
-    
-    def set_caller(self, method_object):
-        if method_object == None:
+
+    def set_caller(self, method_object: ClassMethodObject):
+        if method_object is None:
             raise Exception("ClassMethodObject cannot be SET to be None!")
         self.__caller = method_object

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/")
-def read_root():
+def read_root() -> dict[str, str]:
     return {"message": "Hello, FastAPI World!"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 pytest
 httpx
+pre-commit
+ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,105 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "venv",
+    "env",
+    ".env",
+    ".github",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.10
+target-version = "py310"
+
+# Ruff version = 0.9.7
+required-version = "==0.9.7"
+
+# Source dir is app
+src = [".", "app"]
+
+[lint]
+select = [
+    "E4", "E5", "E7", "E9", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # Pyflakes
+    "FAST", # FastAPI
+    "ANN", # flake8-annotations
+    "ASYNC", # flake8-async
+    "PIE794", # flake8-pie for duplicate class field
+    "Q", # flake8-quotes
+    "I", # isort
+]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.flake8-annotations]
+# __init__'s return type doesn't need to be annotated
+mypy-init-return = true
+
+# When a variable is just a dummy and won't be used,
+# it doesn't have to be annotated
+suppress-dummy-args = true
+
+# When a function doesn't have a return statement
+# or just returns None, the return type doesn't need to
+# be annotated
+suppress-none-returning = true
+
+[lint.isort]
+known-third-party = ["fastapi", "pydantic"]
+
+[lint.pycodestyle]
+ignore-overlong-task-comments = true
+max-line-length = 100
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = true
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/tests/test_element_objects.py
+++ b/tests/test_element_objects.py
@@ -1,8 +1,25 @@
 import unittest
-from app.element_objects import *
+
+from app.element_objects import (
+    AbstractMethodCallObject,
+    AbstractMethodObject,
+    AbstractRelationshipObject,
+    ArgumentObject,
+    ClassMethodCallObject,
+    ClassMethodObject,
+    ClassObject,
+    ControllerMethodCallObject,
+    ControllerMethodObject,
+    FieldObject,
+    ManyToManyRelationshipObject,
+    ManyToOneRelationshipObject,
+    OneToOneRelationshipObject,
+    ParameterObject,
+    TypeObject,
+)
+
 
 class TestClassObject(unittest.TestCase):
-
     def setUp(self):
         self.class_object = ClassObject()
 
@@ -32,12 +49,14 @@ class TestClassObject(unittest.TestCase):
 
     def test_str_representation(self):
         self.class_object.set_name("TestClass")
-        expected_output = """Class Object:\n\tname: TestClass\n\tparent: None\n\tfields:[]\n\t methods: []\n\trelationships: []"""
+        expected_output = (
+            "Class Object:\n\tname: TestClass\n\t"
+            "parent: None\n\tfields:[]\n\t methods: []\n\trelationships: []"
+        )
         self.assertEqual(str(self.class_object), expected_output)
 
 
 class TestFieldObject(unittest.TestCase):
-
     def setUp(self):
         self.field_object = FieldObject()
 
@@ -55,17 +74,17 @@ class TestFieldObject(unittest.TestCase):
         expected_output = """FieldObject:\n\tname: TestField\n\ttype: None"""
         self.assertEqual(str(self.field_object), expected_output)
 
+
 class TestTypeObject(unittest.TestCase):
-    
     def setUp(self):
         self.type_object = TypeObject()
-    
+
     def test_set_name(self):
         self.type_object.set_name("TestType")
         self.assertEqual(self.type_object._TypeObject__name, "TestType")
 
-class TestRelationshipObject(unittest.TestCase):
 
+class TestRelationshipObject(unittest.TestCase):
     def setUp(self):
         self.relationship_object = AbstractRelationshipObject()
         self.source_class = ClassObject()
@@ -73,35 +92,51 @@ class TestRelationshipObject(unittest.TestCase):
 
         self.source_class.set_name("SourceClass")
         self.target_class.set_name("TargetClass")
-    
+
     def test_positive_set_sourceClass(self):
         self.relationship_object.setSourceClass(self.source_class)
-        self.assertEqual(self.relationship_object._AbstractRelationshipObject__sourceClass, self.source_class)
+        self.assertEqual(
+            self.relationship_object._AbstractRelationshipObject__sourceClass,
+            self.source_class,
+        )
 
     def test_positive_set_targetClass(self):
         self.relationship_object.setTargetClass(self.target_class)
-        self.assertEqual(self.relationship_object._AbstractRelationshipObject__targetClass, self.target_class)
-    
+        self.assertEqual(
+            self.relationship_object._AbstractRelationshipObject__targetClass,
+            self.target_class,
+        )
+
     def test_negative_set_sourceClass_as_None(self):
         with self.assertRaises(Exception) as context:
             self.relationship_object.setSourceClass(None)
 
-        self.assertEqual(str(context.exception), "Source Class cannot be SET to be None!")
-    
+        self.assertEqual(
+            str(context.exception), "Source Class cannot be SET to be None!"
+        )
+
     def test_negative_set_targetClass_as_None(self):
         with self.assertRaises(Exception) as context:
             self.relationship_object.setTargetClass(None)
 
-        self.assertEqual(str(context.exception), "Target Class cannot be SET to be None!")
-    
+        self.assertEqual(
+            str(context.exception), "Target Class cannot be SET to be None!"
+        )
+
     def test_edge_source_equals_target(self):
         self.relationship_object.setSourceClass(self.source_class)
         self.relationship_object.setTargetClass(self.source_class)
 
-        self.assertEqual(self.relationship_object._AbstractRelationshipObject__sourceClass, self.source_class)
-        self.assertEqual(self.relationship_object._AbstractRelationshipObject__targetClass, self.source_class)
-        
-        
+        self.assertEqual(
+            self.relationship_object._AbstractRelationshipObject__sourceClass,
+            self.source_class,
+        )
+        self.assertEqual(
+            self.relationship_object._AbstractRelationshipObject__targetClass,
+            self.source_class,
+        )
+
+
 class TestAbstractMethodObject(unittest.TestCase):
     def setUp(self):
         self.method_object = AbstractMethodObject()
@@ -118,12 +153,17 @@ class TestAbstractMethodObject(unittest.TestCase):
     def test_set_returnType(self):
         return_type = TypeObject()
         self.method_object.set_returnType(return_type)
-        self.assertEqual(self.method_object._AbstractMethodObject__returnType, return_type)
+        self.assertEqual(
+            self.method_object._AbstractMethodObject__returnType, return_type
+        )
 
     def test_str_representation(self):
         self.method_object.set_name("TestMethod")
-        expected_output = """MethodObject:\n\tname: TestMethod\n\tparameters: []\n\treturnType: None"""
+        expected_output = (
+            "MethodObject:\n\tname: TestMethod\n\tparameters: []\n\treturnType: None"
+        )
         self.assertEqual(str(self.method_object), expected_output)
+
 
 class TestParameterObject(unittest.TestCase):
     def setUp(self):
@@ -143,6 +183,7 @@ class TestParameterObject(unittest.TestCase):
         expected_output = """ParameterObject:\n\tname: TestParameter\n\ttype: None"""
         self.assertEqual(str(self.parameter_object), expected_output)
 
+
 class TestAbstractMethodCallObject(unittest.TestCase):
     def setUp(self):
         self.method_call_object = AbstractMethodCallObject()
@@ -150,46 +191,53 @@ class TestAbstractMethodCallObject(unittest.TestCase):
     def test_set_method(self):
         method = AbstractMethodObject()
         self.method_call_object.set_method(method)
-        self.assertEqual(self.method_call_object._AbstractMethodCallObject__method, method)
+        self.assertEqual(
+            self.method_call_object._AbstractMethodCallObject__method, method
+        )
 
     def test_add_argument(self):
         argument = ArgumentObject()
         self.method_call_object.add_argument(argument)
-        self.assertEqual(self.method_call_object._AbstractMethodCallObject__arguments, [argument])
+        self.assertEqual(
+            self.method_call_object._AbstractMethodCallObject__arguments, [argument]
+        )
 
     def test_return_var_name(self):
         self.method_call_object.set_returnVarName("TestVarName")
-        self.assertEqual(self.method_call_object._AbstractMethodCallObject__returnVarName, "TestVarName")
+        self.assertEqual(
+            self.method_call_object._AbstractMethodCallObject__returnVarName,
+            "TestVarName",
+        )
 
     def test_str_representation(self):
-        expected_output = """MethodCallObject:\n\tmethod: None\n\targuments: []\n\treturnVarName: """
+        expected_output = (
+            """MethodCallObject:\n\tmethod: None\n\targuments: []\n\treturnVarName: """
+        )
         self.assertEqual(str(self.method_call_object), expected_output)
 
 
 class TestOneToOneRelationshipObject(unittest.TestCase):
-
     def setUp(self):
         self.one_to_one_relationship = OneToOneRelationshipObject()
         self.source_class = ClassObject()
         self.target_class = ClassObject()
 
-class TestManyToOneRelationshipObject(unittest.TestCase):
 
+class TestManyToOneRelationshipObject(unittest.TestCase):
     def setUp(self):
         self.one_to_one_relationship = ManyToOneRelationshipObject()
         self.source_class = ClassObject()
         self.target_class = ClassObject()
 
-class TestManyToManyRelationshipObject(unittest.TestCase):
 
+class TestManyToManyRelationshipObject(unittest.TestCase):
     def setUp(self):
         self.one_to_one_relationship = ManyToManyRelationshipObject()
         self.source_class = ClassObject()
         self.target_class = ClassObject()
-    
 
-        
-class TestAbstractMethodObject(unittest.TestCase):
+
+class TestAbstractMethodObject2(unittest.TestCase):
     def setUp(self):
         self.method_object = AbstractMethodObject()
 
@@ -205,14 +253,19 @@ class TestAbstractMethodObject(unittest.TestCase):
     def test_set_returnType(self):
         return_type = TypeObject()
         self.method_object.set_returnType(return_type)
-        self.assertEqual(self.method_object._AbstractMethodObject__returnType, return_type)
+        self.assertEqual(
+            self.method_object._AbstractMethodObject__returnType, return_type
+        )
 
     def test_str_representation(self):
         self.method_object.set_name("TestMethod")
-        expected_output = """MethodObject:\n\tname: TestMethod\n\tparameters: []\n\treturnType: None"""
+        expected_output = (
+            "MethodObject:\n\tname: TestMethod\n\tparameters: []\n\treturnType: None"
+        )
         self.assertEqual(str(self.method_object), expected_output)
 
-class TestParameterObject(unittest.TestCase):
+
+class TestParameterObject2(unittest.TestCase):
     def setUp(self):
         self.parameter_object = ParameterObject()
 
@@ -230,27 +283,38 @@ class TestParameterObject(unittest.TestCase):
         expected_output = """ParameterObject:\n\tname: TestParameter\n\ttype: None"""
         self.assertEqual(str(self.parameter_object), expected_output)
 
-class TestAbstractMethodCallObject(unittest.TestCase):
+
+class TestAbstractMethodCallObject2(unittest.TestCase):
     def setUp(self):
         self.method_call_object = AbstractMethodCallObject()
 
     def test_set_method(self):
         method = AbstractMethodObject()
         self.method_call_object.set_method(method)
-        self.assertEqual(self.method_call_object._AbstractMethodCallObject__method, method)
+        self.assertEqual(
+            self.method_call_object._AbstractMethodCallObject__method, method
+        )
 
     def test_add_argument(self):
         argument = ArgumentObject()
         self.method_call_object.add_argument(argument)
-        self.assertEqual(self.method_call_object._AbstractMethodCallObject__arguments, [argument])
+        self.assertEqual(
+            self.method_call_object._AbstractMethodCallObject__arguments, [argument]
+        )
 
     def test_return_var_name(self):
         self.method_call_object.set_returnVarName("TestVarName")
-        self.assertEqual(self.method_call_object._AbstractMethodCallObject__returnVarName, "TestVarName")
+        self.assertEqual(
+            self.method_call_object._AbstractMethodCallObject__returnVarName,
+            "TestVarName",
+        )
 
     def test_str_representation(self):
-        expected_output = """MethodCallObject:\n\tmethod: None\n\targuments: []\n\treturnVarName: """
+        expected_output = (
+            """MethodCallObject:\n\tmethod: None\n\targuments: []\n\treturnVarName: """
+        )
         self.assertEqual(str(self.method_call_object), expected_output)
+
 
 class TestArgumentObject(unittest.TestCase):
     def setUp(self):
@@ -259,7 +323,9 @@ class TestArgumentObject(unittest.TestCase):
     def test_set_method_object(self):
         method_object = AbstractMethodObject()
         self.argument_object.set_methodObject(method_object)
-        self.assertEqual(self.argument_object._ArgumentObject__methodObject, method_object)
+        self.assertEqual(
+            self.argument_object._ArgumentObject__methodObject, method_object
+        )
 
     def test_set_name(self):
         self.argument_object.set_name("TestArgument")
@@ -278,61 +344,79 @@ class TestArgumentObject(unittest.TestCase):
         type_obj = TypeObject()
         type_obj.set_name("TestType")
         self.argument_object.set_type(type_obj)
-        expected_output = f"""ArgumentObject:\n\tmethodObject: \n\t[MethodObject:\n\tname: TestMethod\n\tparameters: []\n\treturnType: None]\n\tname: TestArgument\n\ttype: \n\t[{self.argument_object._ArgumentObject__type}]"""
+        expected_output = (
+            "ArgumentObject:\n\tmethodObject: \n\t"
+            "[MethodObject:\n\tname: TestMethod\n\tparameters: []"
+            "\n\treturnType: None]\n\tname: TestArgument\n\ttype: "
+            f"\n\t[{self.argument_object._ArgumentObject__type}]"
+            ""
+        )
         self.assertEqual(str(self.argument_object), expected_output)
 
 
-
 class TestControllerMethodCallObject(unittest.TestCase):
-
     def setUp(self):
         self.controller_method = ControllerMethodCallObject()
         self.class_method = ClassMethodObject()
 
     def test_set_caller(self):
         self.controller_method.set_caller(self.class_method)
-        self.assertEqual(self.controller_method._ControllerMethodCallObject__caller, self.class_method)
+        self.assertEqual(
+            self.controller_method._ControllerMethodCallObject__caller,
+            self.class_method,
+        )
 
 
 class TestControllerMethodObject(unittest.TestCase):
-
     def setUp(self):
         self.controller_method = ControllerMethodObject()
         self.method_call = AbstractMethodCallObject()
 
     def test_add_calls(self):
         self.controller_method.add_calls(self.method_call)
-        self.assertIn(self.method_call, self.controller_method._ControllerMethodObject__calls)
-    
+        self.assertIn(
+            self.method_call, self.controller_method._ControllerMethodObject__calls
+        )
+
+
 class TestClassMethodObject(unittest.TestCase):
     def setUp(self):
         self.class_method_object = ClassMethodObject()
-    
+
     def test_positive_add_class_method_call_object(self):
         class_method_call_object = ClassMethodCallObject()
         self.class_method_object.add_class_method_call(class_method_call_object)
-        self.assertIn(class_method_call_object, self.class_method_object._ClassMethodObject__calls)
-    
+        self.assertIn(
+            class_method_call_object, self.class_method_object._ClassMethodObject__calls
+        )
+
     def test_negative_add_none(self):
         with self.assertRaises(Exception) as context:
             self.class_method_object.add_class_method_call(None)
 
-        self.assertEqual(str(context.exception), "Cannot add None to ClassMethodCallObject!")
+        self.assertEqual(
+            str(context.exception), "Cannot add None to ClassMethodCallObject!"
+        )
+
 
 class TestClassMethodCallObject(unittest.TestCase):
     def setUp(self):
         self.class_method_call = ClassMethodCallObject()
-    
+
     def test_positive_set_caller(self):
         method_object = ClassMethodObject()
         self.class_method_call.set_caller(method_object)
-        self.assertEqual(method_object, self.class_method_call._ClassMethodCallObject__caller)
-    
+        self.assertEqual(
+            method_object, self.class_method_call._ClassMethodCallObject__caller
+        )
+
     def test_negative_set_caller_as_none(self):
         with self.assertRaises(Exception) as context:
             self.class_method_call.set_caller(None)
 
-        self.assertEqual(str(context.exception), "ClassMethodObject cannot be SET to be None!")
+        self.assertEqual(
+            str(context.exception), "ClassMethodObject cannot be SET to be None!"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)
+
 
 def test_read_root():
     response = client.get("/")


### PR DESCRIPTION
- Added the `ruff` linter and formatter to make sure our code style is consistent.
- Added pre-commit hooks that checks our code style before we can make a commit. If there is any violation, then we can't make a commit until it is fixed.
- Added pre-commit hooks that checks our files to check if there is any accidental private credentials added to the staging area before we can make a commit. If there is, we need to remove it before being able to commit.
- Edited `ci.yml` so it runs the test on **every** pull requests instead of only ones targeting `main`, `staging`, or `dev`