### PR TITLE
Add method to transform ClassObjectMethod to code

### DIFF
--- a/app/element_objects.py
+++ b/app/element_objects.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import keyword
+
 
 class ClassObject:
     def __init__(self):
@@ -68,6 +70,17 @@ class AbstractMethodObject:
     def set_returnType(self, returnType: TypeObject):
         self.__returnType = returnType
 
+    def get_name(self) -> str:
+        return self.__name
+
+    def get_parameters(self) -> list[ParameterObject]:
+        # TODO: Make immutable if needed
+        return self.__parameters
+
+    def get_returnType(self) -> TypeObject:
+        # TODO: Make immutable if needed
+        return self.__returnType
+
 
 class ClassMethodObject(AbstractMethodObject):
     def __init__(self):
@@ -78,6 +91,26 @@ class ClassMethodObject(AbstractMethodObject):
         if class_method_call is None:
             raise Exception("Cannot add None to ClassMethodCallObject!")
         self.__calls.append(class_method_call)
+
+    def to_views_code(self) -> str:
+        name = self.get_name()
+        if name is None or not name.isidentifier() or keyword.iskeyword(name):
+            raise ValueError(f"Invalid method name: {name}")
+
+        params = ", ".join([param.to_views_code() for param in self.get_parameters()])
+        res = f"def {name}({params})"
+
+        ret = self.get_returnType()
+        if ret is not None:
+            rettype = ret.get_name()
+            if not rettype.isidentifier() or keyword.iskeyword(rettype):
+                raise ValueError(f"Invalid type: {rettype}")
+            res += f" -> {rettype}"
+        res += ":\n    # TODO: Auto generated function stub\n"
+        res += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        return res
 
 
 class AbstractRelationshipObject:
@@ -103,6 +136,9 @@ class TypeObject:
     def set_name(self, name: str):
         self.__name = name
 
+    def get_name(self) -> str:
+        return self.__name
+
 
 class ParameterObject:
     def __init__(self):
@@ -117,6 +153,24 @@ class ParameterObject:
 
     def set_type(self, type: str):
         self.__type = type
+
+    def to_views_code(self) -> str:
+        if (
+            self.__name is None
+            or not self.__name.isidentifier()
+            or keyword.iskeyword(self.__name)
+        ):
+            raise ValueError(f"Invalid method name: {self.__name}")
+
+        res = self.__name
+        if self.__type is not None:
+            param_type = self.__type.get_name()
+            if not param_type.isidentifier() or keyword.iskeyword(param_type):
+                raise ValueError(f"Invalid type: {param_type}")
+
+            res += f": {param_type}"
+
+        return res
 
 
 class AbstractMethodCallObject:

--- a/app/element_objects.py
+++ b/app/element_objects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import keyword
+from app.utils import is_valid_python_identifier
 
 
 class ClassObject:
@@ -94,7 +94,7 @@ class ClassMethodObject(AbstractMethodObject):
 
     def to_views_code(self) -> str:
         name = self.get_name()
-        if name is None or not name.isidentifier() or keyword.iskeyword(name):
+        if name is None or not is_valid_python_identifier(name):
             raise ValueError(f"Invalid method name: {name}")
 
         params = ", ".join([param.to_views_code() for param in self.get_parameters()])
@@ -103,8 +103,8 @@ class ClassMethodObject(AbstractMethodObject):
         ret = self.get_returnType()
         if ret is not None:
             rettype = ret.get_name()
-            if not rettype.isidentifier() or keyword.iskeyword(rettype):
-                raise ValueError(f"Invalid type: {rettype}")
+            if not is_valid_python_identifier(rettype):
+                raise ValueError(f"Invalid return type: {rettype}")
             res += f" -> {rettype}"
         res += ":\n    # TODO: Auto generated function stub\n"
         res += (
@@ -155,18 +155,14 @@ class ParameterObject:
         self.__type = type
 
     def to_views_code(self) -> str:
-        if (
-            self.__name is None
-            or not self.__name.isidentifier()
-            or keyword.iskeyword(self.__name)
-        ):
-            raise ValueError(f"Invalid method name: {self.__name}")
+        if self.__name is None or not is_valid_python_identifier(self.__name):
+            raise ValueError(f"Invalid param name: {self.__name}")
 
         res = self.__name
         if self.__type is not None:
             param_type = self.__type.get_name()
-            if not param_type.isidentifier() or keyword.iskeyword(param_type):
-                raise ValueError(f"Invalid type: {param_type}")
+            if not is_valid_python_identifier(param_type):
+                raise ValueError(f"Invalid param type: {param_type}")
 
             res += f": {param_type}"
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,5 @@
+from keyword import iskeyword
+
+
+def is_valid_python_identifier(identifier: str) -> bool:
+    return identifier.isidentifier() and not iskeyword(identifier)

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -74,7 +74,7 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         result += (
             "    raise NotImplementedError('method function is not yet implemented')\n"
         )
-        self.assertEqual(result, self.method_with_name)
+        self.assertEqual(result, self.method_with_name.to_views_code())
 
     def test_to_views_code_multiple_params(self):
         # All params should appear in order with its type annotation
@@ -129,12 +129,12 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
     def test_to_views_code_invalid_param_type(self):
         # Should not happen if parser catches it
         # But if the param type of a ParameterObject inside
-        # ClassMethodObject is not Python's, a known type, or has whitespaces
-        # then return ValueError
-        self.param_type.set_name("invalid_type")
+        # ClassMethodObject is not a valid Python identifier or
+        # is a Python keyword, then return ValueError
+        self.param_type.set_name("")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid type: invalid_type")
+            self.assertEqual(str(ctx.exception), "Invalid type: ")
 
         self.param_type.set_name("invalid type")
         with self.assertRaises(ValueError) as ctx:
@@ -160,12 +160,12 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
             self.method_with_parameters.to_views_code()
             self.assertEqual(str(ctx.exception), "Invalid param name: 123")
 
-        self.param_type.set_name("invalid name")
+        self.param.set_name("invalid name")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
             self.assertEqual(str(ctx.exception), "Invalid param name: invalid name")
 
-        self.param_type.set_name("param_!$")
+        self.param.set_name("param_!$")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
             self.assertEqual(str(ctx.exception), "Invalid param name: param_!$")

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -1,0 +1,116 @@
+import unittest
+
+from app.element_objects import ClassMethodObject, ParameterObject, TypeObject
+
+
+class TestClassMethodObjectToViewsCode(unittest.TestCase):
+    def setUp(self):
+        self.empty_method = ClassMethodObject()
+
+        self.method_with_name = ClassMethodObject()
+        self.method_with_name.set_name("method")
+
+        self.method_with_parameters = ClassMethodObject()
+        self.method_with_parameters.set_name("method_params")
+        self.param = ParameterObject()
+        self.param.set_name("param1")
+        self.param_type = TypeObject()
+        self.param_type.set_name("int")
+        self.param.set_type(self.param_type)
+        self.method_with_parameters.add_parameter(self.param)
+
+        self.method_with_return_type = ClassMethodObject()
+        self.method_with_return_type.set_name("method_rettype")
+        self.return_type = TypeObject()
+        self.return_type.set_name("str")
+        self.method_with_return_type.set_returnType(self.return_type)
+
+        self.method_full = ClassMethodObject()
+        self.method_full.set_name("method_full")
+        self.method_full.add_parameter(self.param)
+        self.method_full.set_returnType(self.return_type)
+
+    def test_to_views_code_full(self):
+        # Should have param and type annotations for it as well as return type
+        result = "def method_full(param1: int) -> str:\n"
+        result += "    # TODO: Auto generated function stub\n"
+        result += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        self.assertEqual(result, self.method_full.to_views_code())
+
+    def test_to_views_code_no_return_type(self):
+        # Should have params and its type annotation but no return type
+        result = "def method_params(param1: int):\n"
+        result += "    # TODO: Auto generated function stub\n"
+        result += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        self.assertEqual(result, self.method_with_parameters.to_views_code())
+
+    def test_to_views_code_no_parameters(self):
+        # Should have the return type annotation but no params
+        result = "def method_rettype() -> str:\n"
+        result += "    # TODO: Auto generated function stub\n"
+        result += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        self.assertEqual(result, self.method_with_return_type.to_views_code())
+
+    def test_to_views_code_no_params_or_rettype(self):
+        # Should only have method name and body but no params and return type
+        result = "def method():\n"
+        result += "    # TODO: Auto generated function stub\n"
+        result += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        self.assertEqual(result, self.method_with_name)
+
+    def test_to_views_code_multiple_params(self):
+        # All params should appear in order with its type annotation
+        param2 = ParameterObject()
+        param2.set_name("param2")
+        param2_type = TypeObject()
+        param2_type.set_name("str")
+        param2.set_type(param2_type)
+        self.method_with_parameters.add_parameter(param2)
+
+        param3 = ParameterObject()
+        param3.set_name("param3")
+        param3_type = TypeObject()
+        param3_type.set_name("float")
+        param3.set_type(param3_type)
+        self.method_with_parameters.add_parameter(param3)
+
+        result = "def method_params(param1: int, param2: str, param3: float):\n"
+        result += "    # TODO: Auto generated function stub\n"
+        result += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        self.assertEqual(result, self.method_with_parameters.to_views_code())
+
+    def test_to_views_code_empty_method(self):
+        # Should realistically not happen if the parser catches it
+        # If the ClassMethodObject for some reason does not have a name or is None, then raise
+        # a ValueError
+        with self.assertRaises(ValueError) as ctx:
+            self.empty_method.to_views_code()
+            self.assertEqual(
+                str(ctx.exception),
+                "ClassMethodObject must have at least a name to generate a function",
+            )
+
+    def test_to_views_code_invalid_param_type(self):
+        # Should not happen if parser catches it
+        # But if the param type of a ParameterObject inside
+        # ClassMethodObject is not Python's, a known type, or has whitespaces
+        # then return ValueError
+        self.param_type.set_name("invalid_type")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Unknown Type: invalid_type")
+
+        self.param_type.set_name("invalid type")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Type cannot have whitespaces")

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -105,26 +105,26 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         # or is not a valid Python identifier, raise a ValueError
         with self.assertRaises(ValueError) as ctx:
             self.empty_method.to_views_code()
-            self.assertEqual(
-                str(ctx.exception),
-                "Invalid method name: ",
-            )
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid method name: ",
+        )
 
         self.method_with_name.set_name("123")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_name.to_views_code()
-            self.assertEqual(
-                str(ctx.exception),
-                "Invalid method name: 123",
-            )
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid method name: 123",
+        )
 
         self.method_with_name.set_name("abcd!")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_name.to_views_code()
-            self.assertEqual(
-                str(ctx.exception),
-                "Invalid method name: abcd!",
-            )
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid method name: abcd!",
+        )
 
     def test_to_views_code_invalid_param_type(self):
         # Should not happen if parser catches it
@@ -134,22 +134,22 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         self.param_type.set_name("")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid type: ")
+        self.assertEqual(str(ctx.exception), "Invalid param type: ")
 
         self.param_type.set_name("invalid type")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid type: invalid type")
+        self.assertEqual(str(ctx.exception), "Invalid param type: invalid type")
 
         self.param_type.set_name("123")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid type: 123")
+        self.assertEqual(str(ctx.exception), "Invalid param type: 123")
 
         self.param_type.set_name("int!@")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid type: int!@")
+        self.assertEqual(str(ctx.exception), "Invalid param type: int!@")
 
     def test_to_views_code_invalid_param_name(self):
         # Should not happen if parser catches it
@@ -158,17 +158,17 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         self.param.set_name("123")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid param name: 123")
+        self.assertEqual(str(ctx.exception), "Invalid param name: 123")
 
         self.param.set_name("invalid name")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid param name: invalid name")
+        self.assertEqual(str(ctx.exception), "Invalid param name: invalid name")
 
         self.param.set_name("param_!$")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid param name: param_!$")
+        self.assertEqual(str(ctx.exception), "Invalid param name: param_!$")
 
     def test_to_views_code_invalid_return_type(self):
         # Should not happen if parser catches it
@@ -177,19 +177,19 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         self.return_type.set_name(" ")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_return_type.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid return type:  ")
+        self.assertEqual(str(ctx.exception), "Invalid return type:  ")
 
         self.return_type.set_name("123")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_return_type.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid return type: 123")
+        self.assertEqual(str(ctx.exception), "Invalid return type: 123")
 
-        self.param.set_name("invalid name")
+        self.return_type.set_name("invalid name")
         with self.assertRaises(ValueError) as ctx:
-            self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid return type: invalid name")
+            self.method_with_return_type.to_views_code()
+        self.assertEqual(str(ctx.exception), "Invalid return type: invalid name")
 
-        self.param.set_name("param_!$")
+        self.return_type.set_name("param_!$")
         with self.assertRaises(ValueError) as ctx:
-            self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Invalid return type: param_!$")
+            self.method_with_return_type.to_views_code()
+        self.assertEqual(str(ctx.exception), "Invalid return type: param_!$")

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -169,3 +169,27 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
             self.assertEqual(str(ctx.exception), "Invalid param name: param_!$")
+
+    def test_to_views_code_invalid_return_type(self):
+        # Should not happen if parser catches it
+        # But if the method's return type is not a Python identifier
+        # or is a Python keyword, then raise ValueError
+        self.return_type.set_name(" ")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_return_type.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid return type:  ")
+
+        self.return_type.set_name("123")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_return_type.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid return type: 123")
+
+        self.param.set_name("invalid name")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid return type: invalid name")
+
+        self.param.set_name("param_!$")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid return type: param_!$")

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -108,9 +108,19 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         self.param_type.set_name("invalid_type")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Unknown Type: invalid_type")
+            self.assertEqual(str(ctx.exception), "Invalid type: invalid_type")
 
         self.param_type.set_name("invalid type")
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
-            self.assertEqual(str(ctx.exception), "Type cannot have whitespaces")
+            self.assertEqual(str(ctx.exception), "Invalid type: invalid type")
+
+        self.param_type.set_name("123")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid type: 123")
+
+        self.param_type.set_name("int!@")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid type: int!@")

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -124,3 +124,22 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             self.method_with_parameters.to_views_code()
             self.assertEqual(str(ctx.exception), "Invalid type: int!@")
+
+    def test_to_views_code_invalid_param_name(self):
+        # Should not happen if parser catches it
+        # But if the param name is not a Python identifier
+        # or is a Python keyword, then raise ValueError
+        self.param.set_name("123")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid param name: 123")
+
+        self.param_type.set_name("invalid name")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid param name: invalid name")
+
+        self.param_type.set_name("param_!$")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_parameters.to_views_code()
+            self.assertEqual(str(ctx.exception), "Invalid param name: param_!$")

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -89,15 +89,31 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         )
         self.assertEqual(result, self.method_with_parameters.to_views_code())
 
-    def test_to_views_code_empty_method(self):
-        # Should realistically not happen if the parser catches it
-        # If the ClassMethodObject for some reason does not have a name or is None, then raise
-        # a ValueError
+    def test_to_views_code_invalid_method_name(self):
+        # Should not happen if the parser catches it
+        # If the ClassMethodObject __name attribute is a Python keyword
+        # or is not a valid Python identifier, raise a ValueError
         with self.assertRaises(ValueError) as ctx:
             self.empty_method.to_views_code()
             self.assertEqual(
                 str(ctx.exception),
-                "ClassMethodObject must have at least a name to generate a function",
+                "Invalid method name: ",
+            )
+
+        self.method_with_name.set_name("123")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_name.to_views_code()
+            self.assertEqual(
+                str(ctx.exception),
+                "Invalid method name: 123",
+            )
+
+        self.method_with_name.set_name("abcd!")
+        with self.assertRaises(ValueError) as ctx:
+            self.method_with_name.to_views_code()
+            self.assertEqual(
+                str(ctx.exception),
+                "Invalid method name: abcd!",
             )
 
     def test_to_views_code_invalid_param_type(self):

--- a/tests/test_class_method_object_to_views.py
+++ b/tests/test_class_method_object_to_views.py
@@ -48,6 +48,16 @@ class TestClassMethodObjectToViewsCode(unittest.TestCase):
         )
         self.assertEqual(result, self.method_with_parameters.to_views_code())
 
+    def test_to_views_code_param_no_type(self):
+        # Parameter doesn't have a type somehow
+        result = "def method_params(param1):\n"
+        result += "    # TODO: Auto generated function stub\n"
+        result += (
+            "    raise NotImplementedError('method function is not yet implemented')\n"
+        )
+        self.param.set_type(None)
+        self.assertEqual(result, self.method_with_parameters.to_views_code())
+
     def test_to_views_code_no_parameters(self):
         # Should have the return type annotation but no params
         result = "def method_rettype() -> str:\n"


### PR DESCRIPTION
- Add `to_views_code` method on ClassObjectMethod to transform it into standard Python code
- Add `to_views_code` method on ParameterObject to transform it into standard Python function parameter
- Add getters for attributes on ClassObjectMethod and TypeObject