### PR TITLE
Refactored some missed parts to improve code quality

### DIFF
--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -101,12 +101,12 @@ class AbstractRelationshipObject(ABC):
 
     def set_source_class(self, source_class: ClassObject):
         if source_class is None:
-            raise Exception("Source Class cannot be SET to be None!")
+            raise ValueError("Source Class cannot be SET to be None!")
         self.__source_class = source_class
 
     def set_target_class(self, target_class: ClassObject):
         if target_class is None:
-            raise Exception("Target Class cannot be SET to be None!")
+            raise ValueError("Target Class cannot be SET to be None!")
         self.__target_class = target_class
 
     def setSourceClassOwnAmount(self, amount: str):

--- a/app/models/methods.py
+++ b/app/models/methods.py
@@ -85,7 +85,7 @@ class ClassMethodObject(AbstractMethodObject):
 
     def add_class_method_call(self, class_method_call: ClassMethodCallObject):
         if class_method_call is None:
-            raise Exception("Cannot add None to ClassMethodCallObject!")
+            raise ValueError("Cannot add None to ClassMethodCallObject!")
         self.__calls.append(class_method_call)
 
     def to_views_code(self) -> str:

--- a/app/models/properties.py
+++ b/app/models/properties.py
@@ -102,7 +102,7 @@ class ParameterObject:
     def set_name(self, name: str):
         self.__name = name
 
-    def set_type(self, type: str):
+    def set_type(self, type: TypeObject):
         self.__type = type
 
     def to_views_code(self) -> str:

--- a/app/parse_json_to_object_seq.py
+++ b/app/parse_json_to_object_seq.py
@@ -247,9 +247,8 @@ class ParseJsonToObjectSeq:
             class_obj.add_method(method)
 
         method_call_dictionary = self.__method_call[(start_id, end_id)]
-        if condition is not None:
-            if method_call_dictionary["end"] == end_id:
-                method_call_dictionary["condition"] = condition
+        if condition is not None and method_call_dictionary["end"] == end_id:
+            method_call_dictionary["condition"] = condition
         method_call_dictionary["method"] = method
 
     def process_edge_into_classobject(self):

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -160,7 +160,7 @@ class TestAbstractRelationshipObject(unittest.TestCase):
         )
 
     def test_negative_set_source_class_as_None(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             self.relationship_object.set_source_class(None)
 
         self.assertEqual(
@@ -168,7 +168,7 @@ class TestAbstractRelationshipObject(unittest.TestCase):
         )
 
     def test_negative_set_target_class_as_None(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             self.relationship_object.set_target_class(None)
 
         self.assertEqual(

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -273,13 +273,13 @@ class TestClassMethodCallObject(unittest.TestCase):
         obj = ClassMethodCallObject()
         with self.assertRaises(ValueError) as context:
             obj.set_instance_name("")
-        self.assertTrue("instance_name cannot be empty!" in str(context.exception))
+        self.assertIn("instance_name cannot be empty!", str(context.exception))
 
     def test_set_instance_name_none(self):
         obj = ClassMethodCallObject()
         with self.assertRaises(ValueError) as context:
             obj.set_instance_name(None)
-        self.assertTrue("instance_name cannot be empty!" in str(context.exception))
+        self.assertIn("instance_name cannot be empty!", str(context.exception))
 
     def test_get_instance_name_empty(self):
         obj = ClassMethodCallObject()

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -81,7 +81,7 @@ class TestClassMethodObject(unittest.TestCase):
         )
 
     def test_negative_add_none(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             self.class_method_object.add_class_method_call(None)
 
         self.assertEqual(
@@ -257,7 +257,7 @@ class TestClassMethodCallObject(unittest.TestCase):
         )
 
     def test_negative_set_caller_as_none(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             self.class_method_call_object.set_caller(None)
 
         self.assertEqual(


### PR DESCRIPTION
- Changed generic raise Exceptions into ValueError as it is more appropriate for the occasion.
- Changed `assertTrue(a in b)` to `assertIn(a, b)` instead to make it have better error message.
- Merged two if conditions that doesn't really have any benefit being separate.
- Fixed type annotation of parameter `type` in the `set_type` method of `ParameterObject` from `str` to `TypeObject`.