### PR TITLE
add support for alphanumerical and underscore in class diagram object names

### DIFF
--- a/app/parse_json_to_object_class.py
+++ b/app/parse_json_to_object_class.py
@@ -17,7 +17,10 @@ class ParseJsonToObjectClass:
     def __init__(self, data: str):
         self.__json = data
         if isinstance(data, str):
-            self.__json = json.loads(data)
+            try:
+                self.__json = json.loads(data)
+            except json.JSONDecodeError:
+                raise ValueError("Error: Invalid JSON format")
         self.__classes = []
 
     def check_name(self, name: str) -> bool:
@@ -26,7 +29,7 @@ class ParseJsonToObjectClass:
     def parse_classes(self) -> list:
         data = self.__json
 
-        if "nodes" not in data.keys() or data["nodes"] == "":
+        if "nodes" not in data.keys() or data["nodes"] == "" or data["nodes"] == []:
             raise ValueError("Error: nodes not found in the json")
 
         # iterate all class in json
@@ -127,8 +130,8 @@ class ParseJsonToObjectClass:
                             class_obj.add_field(attr)
                         else:
                             raise ValueError(
-                                f"Error: attribute name or type is not valid: {attr_name} \
-                                    {attr_type_name}"
+                                f"Error: attribute name or type is not valid: {attr_name}, "
+                                f"{attr_type_name}"
                             )
 
             self.__classes.append(class_obj)

--- a/app/parse_json_to_object_class.py
+++ b/app/parse_json_to_object_class.py
@@ -10,6 +10,8 @@ from app.models.diagram import (
 from app.models.methods import ClassMethodObject
 from app.models.properties import FieldObject, ParameterObject, TypeObject
 
+from .utils import is_valid_python_identifier
+
 
 class ParseJsonToObjectClass:
     def __init__(self, data: str):
@@ -19,9 +21,7 @@ class ParseJsonToObjectClass:
         self.__classes = []
 
     def check_name(self, name: str) -> bool:
-        if name.isalpha():
-            return True
-        return False
+        return is_valid_python_identifier(name)
 
     def parse_classes(self) -> list:
         data = self.__json

--- a/tests/test_parse_class.py
+++ b/tests/test_parse_class.py
@@ -12,29 +12,9 @@ from app.parse_json_to_object_class import ParseJsonToObjectClass
 
 class TestParseJsonToObjectClass(unittest.TestCase):
     def test_parse(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "",
-                "name": "Pengelola",
-                "x": 330,
-                "y": 10,
-                "attributes": "- isAdmin: boolean",
-                "id": 0,
-                "type": "ClassNode"
-                },
-                {
-                "methods": "+ getBesaranDenda(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-        }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_1.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         result = parser.parse_classes()
         self.assertEqual(result, parser._ParseJsonToObjectClass__classes)
@@ -56,67 +36,36 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         )
 
     def test_empty_nodes(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": []
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_2.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(Exception) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: nodes not found in the json")
 
     def test_missing_nodes(self):
-        data = """{
-            "diagram": "ClassDiagram"
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_3.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: nodes not found in the json")
 
     def test_invalid_json(self):
-        data = """{
-        "diagram": "ClassDiagram",
-        "nodes": [
-                {
-                "methods": "",
-                "name": "Pengelola",
-                "x": 330,
-                "y": 10,
-                "attributes": "- isAdmin: boolean",
-                "id": 0,
-                "type": "ClassNode"
-                },
-                {
-                "methods": "+ getBesaranDenda(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                },
-            """  # noqa: E501
-
+        data = ""
+        with open("tests/testdata/parse_class_4.json") as file:
+            data = file.read()
+            print(data)
         with self.assertRaises(ValueError) as context:
             ParseJsonToObjectClass(data)
         self.assertEqual(str(context.exception), "Error: Invalid JSON format")
 
     def test_missing_attributes(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "",
-                "name": "Pengelola",
-                "x": 330,
-                "y": 10,
-                "attributes": "",
-                "id": 0,
-                "type": "ClassNode"
-                }
-            ]
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_5.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         result = parser.parse_classes()
         self.assertEqual(result, parser._ParseJsonToObjectClass__classes)
@@ -137,107 +86,36 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         )
 
     def test_missing_method_name(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "",
-                "name": "",
-                "x": 330,
-                "y": 10,
-                "attributes": "- isAdmin: boolean",
-                "id": 0,
-                "type": "ClassNode"
-                },
-                {
-                "methods": "+ getBesaranDenda(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-            }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_6.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: class not found in the json")
 
     def test_missing_method_attributes(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "",
-                "name": "Pengelola",
-                "x": 330,
-                "y": 10,
-                "attributes": "- isAdmin: boolean",
-                "id": 0,
-                "type": "ClassNode"
-                },
-                {
-                "methods": "+ getBesaranDenda(int: 123): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-            }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_7.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def test_invalid_class_name(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "",
-                "name": "Pengelola!@",
-                "x": 330,
-                "y": 10,
-                "attributes": "- isAdmin: boolean",
-                "id": 0,
-                "type": "ClassNode"
-                },
-                {
-                "methods": "+ getBesaranDenda(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-            }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_8.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: class name is not valid")
 
     def test_invalid_method_name(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ getBesaranDenda@(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-            }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_9.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
@@ -246,40 +124,18 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         )
 
     def test_invalid_parameter_name(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ getBesaranDenda(int: this is wrong): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-            }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_10.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def test_invalid_attribute_name(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ getBesaranDenda(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
-                "name": "Peminjaman",
-                "x": 310,
-                "y": 270,
-                "attributes": "- @ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
-                "id": 1,
-                "type": "ClassNode"
-                }
-            ]
-            }"""  # noqa: E501
+        data = ""
+        with open("tests/testdata/parse_class_11.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
@@ -289,79 +145,35 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         )
 
     def test_valid_method_parameter(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ methodName(parama: type, paramx: int): bool",
-                "name": "ClassName",
-                "x": 330,
-                "y": 10,
-                "attributes": "- attribute: type",
-                "id": 0,
-                "type": "ClassNode"
-                }
-            ]
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_12.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         result = parser.parse_classes()
         self.assertEqual(result, parser._ParseJsonToObjectClass__classes)
 
     def test_invalid_method_parameter(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ methodName(param1: type1, param2: )",
-                "name": "ClassName",
-                "x": 330,
-                "y": 10,
-                "attributes": "- attribute: type",
-                "id": 0,
-                "type": "ClassNode"
-                }
-            ]
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_13.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: method return type not found")
 
     def test_invalid_method_parameter_name(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ methodName(param1: type1, param@!: type2): bool",
-                "name": "ClassName",
-                "x": 330,
-                "y": 10,
-                "attributes": "- attribute: type",
-                "id": 0,
-                "type": "ClassNode"
-                }
-            ]
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_14.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
         self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def test_invalid_method_parameter_type(self):
-        data = """{
-            "diagram": "ClassDiagram",
-            "nodes": [
-                {
-                "methods": "+ methodName(param1: type1, param2: invalid type): bool",
-                "name": "ClassName",
-                "x": 330,
-                "y": 10,
-                "attributes": "- attribute: type",
-                "id": 0,
-                "type": "ClassNode"
-                }
-            ]
-        }"""
+        data = ""
+        with open("tests/testdata/parse_class_15.json") as file:
+            data = file.read()
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()

--- a/tests/test_parse_class.py
+++ b/tests/test_parse_class.py
@@ -63,7 +63,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(Exception) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: nodes not found in the json")
+        self.assertEqual(str(context.exception), "Error: nodes not found in the json")
 
     def test_missing_nodes(self):
         data = """{
@@ -72,12 +72,12 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: nodes not found in the json")
+        self.assertEqual(str(context.exception), "Error: nodes not found in the json")
 
     def test_invalid_json(self):
         data = """{
         "diagram": "ClassDiagram",
-            "nodes": [
+        "nodes": [
                 {
                 "methods": "",
                 "name": "Pengelola",
@@ -95,12 +95,12 @@ class TestParseJsonToObjectClass(unittest.TestCase):
                 "attributes": "- ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
                 "id": 1,
                 "type": "ClassNode"
-                }
-            ]"""  # noqa: E501
+                },
+            """  # noqa: E501
 
-        with self.assertRaises(json.JSONDecodeError) as context:
+        with self.assertRaises(ValueError) as context:
             ParseJsonToObjectClass(data)
-            self.assertEqual(context.exception, "Error: nodes not found in the json")
+        self.assertEqual(str(context.exception), "Error: Invalid JSON format")
 
     def test_missing_attributes(self):
         data = """{
@@ -163,7 +163,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: class not found in the json")
+        self.assertEqual(str(context.exception), "Error: class not found in the json")
 
     def test_missing_method_attributes(self):
         data = """{
@@ -192,7 +192,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: parameter name is not valid")
+        self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def test_invalid_class_name(self):
         data = """{
@@ -200,7 +200,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
             "nodes": [
                 {
                 "methods": "",
-                "name": "Pengelola123",
+                "name": "Pengelola!@",
                 "x": 330,
                 "y": 10,
                 "attributes": "- isAdmin: boolean",
@@ -221,14 +221,14 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: class name is not valid")
+        self.assertEqual(str(context.exception), "Error: class name is not valid")
 
     def test_invalid_method_name(self):
         data = """{
             "diagram": "ClassDiagram",
             "nodes": [
                 {
-                "methods": "+ getBesaranDenda123(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
+                "methods": "+ getBesaranDenda@(): integer\\n+ getTglPinjam(): Date\\n+ getTglKembali(): Date",
                 "name": "Peminjaman",
                 "x": 310,
                 "y": 270,
@@ -241,7 +241,9 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "ValueError: method name is not valid")
+        self.assertEqual(
+            str(context.exception), "Error: method or method rettype name is not valid"
+        )
 
     def test_invalid_parameter_name(self):
         data = """{
@@ -261,7 +263,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: parameter name is not valid")
+        self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def test_invalid_attribute_name(self):
         data = """{
@@ -272,7 +274,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
                 "name": "Peminjaman",
                 "x": 310,
                 "y": 270,
-                "attributes": "- ID_@: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
+                "attributes": "- @ID: String\\n- isDikembalikan: boolean\\n- tglPinjam: Date\\n- tglKembali: Date\\n- isLunasDenda: boolean\\n- besaranDenda: integer",
                 "id": 1,
                 "type": "ClassNode"
                 }
@@ -281,9 +283,10 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(
-                context.exception, "Error: attribute name or type is not valid"
-            )
+        self.assertEqual(
+            str(context.exception),
+            "Error: attribute name or type is not valid: @ID, String",
+        )
 
     def test_valid_method_parameter(self):
         data = """{
@@ -322,7 +325,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: method parameter is not valid")
+        self.assertEqual(str(context.exception), "Error: method return type not found")
 
     def test_invalid_method_parameter_name(self):
         data = """{
@@ -342,7 +345,9 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: parameter name is not valid")
+            self.assertEqual(
+                str(context.exception), "Error: parameter name is not valid"
+            )
 
     def test_invalid_method_parameter_type(self):
         data = """{
@@ -362,7 +367,9 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(context.exception, "Error: parameter name is not valid")
+            self.assertEqual(
+                str(context.exception), "Error: parameter name is not valid"
+            )
 
     def setUp(self):
         # Mocking the classes

--- a/tests/test_parse_class.py
+++ b/tests/test_parse_class.py
@@ -332,7 +332,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
             "diagram": "ClassDiagram",
             "nodes": [
                 {
-                "methods": "+ methodName(param1: type1, param2: invalid name)",
+                "methods": "+ methodName(param1: type1, param@!: type2): bool",
                 "name": "ClassName",
                 "x": 330,
                 "y": 10,
@@ -345,16 +345,14 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(
-                str(context.exception), "Error: parameter name is not valid"
-            )
+        self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def test_invalid_method_parameter_type(self):
         data = """{
             "diagram": "ClassDiagram",
             "nodes": [
                 {
-                "methods": "+ methodName(param1: type1, param2: invalid type)",
+                "methods": "+ methodName(param1: type1, param2: invalid type): bool",
                 "name": "ClassName",
                 "x": 330,
                 "y": 10,
@@ -367,9 +365,7 @@ class TestParseJsonToObjectClass(unittest.TestCase):
         parser = ParseJsonToObjectClass(data)
         with self.assertRaises(ValueError) as context:
             parser.parse_classes()
-            self.assertEqual(
-                str(context.exception), "Error: parameter name is not valid"
-            )
+        self.assertEqual(str(context.exception), "Error: parameter name is not valid")
 
     def setUp(self):
         # Mocking the classes

--- a/tests/testdata/parse_class_1.json
+++ b/tests/testdata/parse_class_1.json
@@ -1,0 +1,23 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "",
+        "name": "Pengelola",
+        "x": 330,
+        "y": 10,
+        "attributes": "- isAdmin: boolean",
+        "id": 0,
+        "type": "ClassNode"
+        },
+        {
+        "methods": "+ getBesaranDenda(): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_10.json
+++ b/tests/testdata/parse_class_10.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ getBesaranDenda(int: this is wrong): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_11.json
+++ b/tests/testdata/parse_class_11.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ getBesaranDenda(): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- @ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_12.json
+++ b/tests/testdata/parse_class_12.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ methodName(parama: type, paramx: int): bool",
+        "name": "ClassName",
+        "x": 330,
+        "y": 10,
+        "attributes": "- attribute: type",
+        "id": 0,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_13.json
+++ b/tests/testdata/parse_class_13.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ methodName(param1: type1, param2: )",
+        "name": "ClassName",
+        "x": 330,
+        "y": 10,
+        "attributes": "- attribute: type",
+        "id": 0,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_14.json
+++ b/tests/testdata/parse_class_14.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ methodName(param1: type1, param@!: type2): bool",
+        "name": "ClassName",
+        "x": 330,
+        "y": 10,
+        "attributes": "- attribute: type",
+        "id": 0,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_15.json
+++ b/tests/testdata/parse_class_15.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ methodName(param1: type1, param2: invalid type): bool",
+        "name": "ClassName",
+        "x": 330,
+        "y": 10,
+        "attributes": "- attribute: type",
+        "id": 0,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_2.json
+++ b/tests/testdata/parse_class_2.json
@@ -1,0 +1,4 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": []
+}

--- a/tests/testdata/parse_class_3.json
+++ b/tests/testdata/parse_class_3.json
@@ -1,0 +1,3 @@
+{
+    "diagram": "ClassDiagram"
+}

--- a/tests/testdata/parse_class_4.json
+++ b/tests/testdata/parse_class_4.json
@@ -1,0 +1,21 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+            {
+            "methods": "",
+            "name": "Pengelola",
+            "x": 330,
+            "y": 10,
+            "attributes": "- isAdmin: boolean",
+            "id": 0,
+            "type": "ClassNode"
+            },
+            {
+            "methods": "+ getBesaranDenda(): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+            "name": "Peminjaman",
+            "x": 310,
+            "y": 270,
+            "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+            "id": 1,
+            "type": "ClassNode"
+            },

--- a/tests/testdata/parse_class_5.json
+++ b/tests/testdata/parse_class_5.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "",
+        "name": "Pengelola",
+        "x": 330,
+        "y": 10,
+        "attributes": "",
+        "id": 0,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_6.json
+++ b/tests/testdata/parse_class_6.json
@@ -1,0 +1,23 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "",
+        "name": "",
+        "x": 330,
+        "y": 10,
+        "attributes": "- isAdmin: boolean",
+        "id": 0,
+        "type": "ClassNode"
+        },
+        {
+        "methods": "+ getBesaranDenda(): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_7.json
+++ b/tests/testdata/parse_class_7.json
@@ -1,0 +1,23 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "",
+        "name": "Pengelola",
+        "x": 330,
+        "y": 10,
+        "attributes": "- isAdmin: boolean",
+        "id": 0,
+        "type": "ClassNode"
+        },
+        {
+        "methods": "+ getBesaranDenda(int: 123): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_8.json
+++ b/tests/testdata/parse_class_8.json
@@ -1,0 +1,23 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "",
+        "name": "Pengelola!@",
+        "x": 330,
+        "y": 10,
+        "attributes": "- isAdmin: boolean",
+        "id": 0,
+        "type": "ClassNode"
+        },
+        {
+        "methods": "+ getBesaranDenda(): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}

--- a/tests/testdata/parse_class_9.json
+++ b/tests/testdata/parse_class_9.json
@@ -1,0 +1,14 @@
+{
+    "diagram": "ClassDiagram",
+    "nodes": [
+        {
+        "methods": "+ getBesaranDenda@(): integer\n+ getTglPinjam(): Date\n+ getTglKembali(): Date",
+        "name": "Peminjaman",
+        "x": 310,
+        "y": 270,
+        "attributes": "- ID: String\n- isDikembalikan: boolean\n- tglPinjam: Date\n- tglKembali: Date\n- isLunasDenda: boolean\n- besaranDenda: integer",
+        "id": 1,
+        "type": "ClassNode"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request includes several changes to the `ParseJsonToObjectClass` class and its associated test cases to improve error handling and validation. The most important changes include adding validation for JSON format, enhancing identifier checks, and updating test cases to reflect these improvements.

### Enhancements and Error Handling:

* [`app/parse_json_to_object_class.py`](diffhunk://#diff-c0001b02d7e400a8e68c0efcbb1e4413600f9a1616432b24069f3aece1ecfe05R13-R32): Added validation for JSON format and replaced the `check_name` method with a call to `is_valid_python_identifier` to improve identifier validation. [[1]](diffhunk://#diff-c0001b02d7e400a8e68c0efcbb1e4413600f9a1616432b24069f3aece1ecfe05R13-R32) [[2]](diffhunk://#diff-c0001b02d7e400a8e68c0efcbb1e4413600f9a1616432b24069f3aece1ecfe05L130-R134)
* [`app/parse_json_to_object_class.py`](diffhunk://#diff-c0001b02d7e400a8e68c0efcbb1e4413600f9a1616432b24069f3aece1ecfe05R13-R32): Updated the `parse_classes` method to raise an error if the "nodes" key is missing, empty, or an empty list.

### Test Case Updates:

* [`tests/test_parse_class.py`](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L66-R66): Updated multiple test cases to use `str(context.exception)` for better error message comparison. [[1]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L66-R66) [[2]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L75-R75) [[3]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L98-R103) [[4]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L166-R166) [[5]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L195-R203) [[6]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L224-R231) [[7]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L244-R246) [[8]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L264-R266) [[9]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L275-R277) [[10]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L285-R288) [[11]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L325-R335) [[12]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L345-R355) [[13]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L365-R368)
* [`tests/test_parse_class.py`](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L98-R103): Modified test cases to handle invalid JSON format and various invalid identifiers in class names, method names, attribute names, and parameter names. [[1]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L98-R103) [[2]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L195-R203) [[3]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L224-R231) [[4]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L244-R246) [[5]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L264-R266) [[6]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L275-R277) [[7]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L285-R288) [[8]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L325-R335) [[9]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L345-R355) [[10]](diffhunk://#diff-c0a0bf690dc8933495a07376db1c9212991aa54ca7a73f6978aa0bf24a2dc947L365-R368)