### PR TITLE
BUG-FIX-2-Fix Method Call Order

### DIFF
--- a/app/parse_json_to_object_seq.py
+++ b/app/parse_json_to_object_seq.py
@@ -354,34 +354,37 @@ please consult the user manual document on how to name return variables"
         self.process_edge_into_classobject()
 
         rev_call_tree = {}
-        for callee_id, call_node in self.__call_nodes.items():
-            caller_id = call_node.get("caller", None)
-            if caller_id not in valid_caller:
-                continue
+        for edge in self.__edges:
+            if edge["type"] == "CallEdge":
+                callee_id = edge["end"]
+                call_node = self.__call_nodes[callee_id]
+                caller_id = call_node.get("caller", None)
+                if caller_id not in valid_caller:
+                    continue
 
-            self.process_self_call(caller_id, callee_id, rev_call_tree, call_node)
+                self.process_self_call(caller_id, callee_id, rev_call_tree, call_node)
 
-            caller_method = self.__call_nodes[caller_id]["method"]
-            callee_method = call_node["method"]
-            ret_var = call_node.get("ret_var", None)
+                caller_method = self.__call_nodes[caller_id]["method"]
+                callee_method = call_node["method"]
+                ret_var = call_node.get("ret_var", None)
 
-            method_call_dictionary = self.__method_call[(caller_id, callee_id)]
+                method_call_dictionary = self.__method_call[(caller_id, callee_id)]
 
-            call_obj = self.process_call_obj(
-                caller_method, callee_method, method_call_dictionary, callee_id
-            )
+                call_obj = self.process_call_obj(
+                    caller_method, callee_method, method_call_dictionary, callee_id
+                )
 
-            method_call_dictionary["method_call"] = call_obj
+                method_call_dictionary["method_call"] = call_obj
 
-            self.add_argument_object(callee_method, call_obj)
+                self.add_argument_object(callee_method, call_obj)
 
-            if ret_var is not None:
-                call_obj.set_return_var_name(ret_var)
+                if ret_var is not None:
+                    call_obj.set_return_var_name(ret_var)
 
-            if isinstance(caller_method, ClassMethodObject):
-                caller_method.add_class_method_call(call_obj)
-            else:
-                caller_method.add_call(call_obj)
+                if isinstance(caller_method, ClassMethodObject):
+                    caller_method.add_class_method_call(call_obj)
+                else:
+                    caller_method.add_call(call_obj)
 
     def check_call_depth(
         self, rev_call_tree: dict[int, int], callee: int

--- a/tests/test_parse_json_to_object_seq.py
+++ b/tests/test_parse_json_to_object_seq.py
@@ -99,16 +99,6 @@ class TestParseJsonToObjectSeq(unittest.TestCase):
             str(context.exception), "Duplicate class name 'Buku' on sequence diagram"
         )
 
-    # def test_edge_duplicate_method_name(self):
-    #     with open("tests/test_duplicate_method_name_seq.txt", "r", encoding="utf-8") as file:
-    #         json_data = file.read()
-
-    #     with self.assertRaises(Exception) as context:
-    #         parser = ParseJsonToObjectSeq()
-    #         parser.set_json(json_data)
-    #         parser.parse()
-    #     self.assertEqual(str(context.exception), "Duplicate method!")
-
     def test_edge_duplicate_attribute(self):
         with open(
             "tests/test_duplicate_attribute_seq.txt", "r", encoding="utf-8"

--- a/tests/test_parse_json_to_object_seq.py
+++ b/tests/test_parse_json_to_object_seq.py
@@ -198,103 +198,154 @@ class TestParseJsonToObjectSeq(unittest.TestCase):
         self.assertEqual(len(parsed_value_controller[2].get_call()), 2)
         self.assertEqual(
             parsed_value_controller[2].get_call()[0].get_methods().get_name(),
+            "getBuku",
+        )
+
+        self.assertEqual(
+            len(parsed_value_controller[2].get_call()[0].get_arguments()), 1
+        )
+        self.assertEqual(
+            parsed_value_controller[2].get_call()[0].get_arguments()[0].get_name(),
+            "isbn",
+        )
+
+        self.assertEqual(
+            parsed_value_controller[2].get_call()[1].get_methods().get_name(),
             "getDetailBuku",
         )
+
         self.assertEqual(
-            len(parsed_value_controller[2].get_call()[0].get_arguments()), 0
-        )
-        self.assertEqual(
-            parsed_value_controller[2].get_call()[1].get_methods().get_name(), "getBuku"
-        )
-        self.assertEqual(
-            len(parsed_value_controller[2].get_call()[1].get_arguments()), 1
-        )
-        self.assertEqual(
-            parsed_value_controller[2].get_call()[1].get_arguments()[0].get_name(),
-            "isbn",
+            len(parsed_value_controller[2].get_call()[1].get_arguments()), 0
         )
 
         self.assertEqual(len(parsed_value_controller[3].get_call()), 0)
 
         self.assertEqual(len(parsed_value_controller[4].get_call()), 3)
+
         self.assertEqual(
-            parsed_value_controller[4].get_call()[0].get_methods().get_name(),
+            parsed_value_controller[4].get_call()[0].get_methods().get_name(), "isValid"
+        )
+        self.assertEqual(
+            len(parsed_value_controller[4].get_call()[0].get_arguments()), 1
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4].get_call()[0].get_arguments()[0].get_name(),
+            "dataAnggota",
+        )
+
+        self.assertEqual(
+            len(parsed_value_controller[4].get_call()[0].get_methods().get_calls()), 0
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4].get_call()[1].get_methods().get_name(),
             "prosesPeminjamanValidKeanggotaan",
         )
         self.assertEqual(
-            parsed_value_controller[4].get_call()[0].get_condition(),
+            parsed_value_controller[4].get_call()[1].get_condition(),
             "isValid",
         )
         self.assertEqual(
-            len(parsed_value_controller[4].get_call()[0].get_arguments()), 0
+            len(parsed_value_controller[4].get_call()[1].get_arguments()), 0
         )
         self.assertEqual(
-            len(parsed_value_controller[4].get_call()[0].get_methods().get_call()), 3
+            len(parsed_value_controller[4].get_call()[1].get_methods().get_call()), 3
         )
+
         self.assertEqual(
             parsed_value_controller[4]
-            .get_call()[0]
+            .get_call()[1]
             .get_methods()
             .get_call()[0]
             .get_methods()
             .get_name(),
-            "prosesPeminjamanTidakMemilikiTanggungan",
+            "hasTanggungan",
         )
+
         self.assertEqual(
             len(
                 parsed_value_controller[4]
-                .get_call()[0]
+                .get_call()[1]
                 .get_methods()
                 .get_call()[0]
+                .get_arguments()
+            ),
+            1,
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[0]
+            .get_arguments()[0]
+            .get_name(),
+            "peminjam",
+        )
+
+        self.assertEqual(
+            len(
+                parsed_value_controller[4]
+                .get_call()[1]
+                .get_methods()
+                .get_call()[0]
+                .get_methods()
+                .get_calls()
+            ),
+            1,
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[0]
+            .get_methods()
+            .get_calls()[0]
+            .get_method()
+            .get_name(),
+            "hasTanggungan",
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[1]
+            .get_methods()
+            .get_name(),
+            "prosesPeminjamanTidakMemilikiTanggungan",
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[1]
+            .get_condition(),
+            "not hasTanggunganResult",
+        )
+
+        self.assertEqual(
+            len(
+                parsed_value_controller[4]
+                .get_call()[1]
+                .get_methods()
+                .get_call()[1]
                 .get_methods()
                 .get_call()
             ),
             2,
         )
-        self.assertEqual(
-            parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
-            .get_methods()
-            .get_name(),
-            "showNotifikasiBerhasilPinjam",
-        )
-        self.assertEqual(
-            len(
-                parsed_value_controller[4]
-                .get_call()[0]
-                .get_methods()
-                .get_call()[0]
-                .get_methods()
-                .get_call()[0]
-                .get_methods()
-                .get_call()
-            ),
-            0,
-        )
-        self.assertEqual(
-            len(
-                parsed_value_controller[4]
-                .get_call()[0]
-                .get_methods()
-                .get_call()[0]
-                .get_methods()
-                .get_call()[0]
-                .get_arguments()
-            ),
-            0,
-        )
 
         self.assertEqual(
             parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
+            .get_call()[1]
             .get_methods()
             .get_call()[1]
+            .get_methods()
+            .get_call()[0]
             .get_methods()
             .get_name(),
             "borrow",
@@ -302,38 +353,26 @@ class TestParseJsonToObjectSeq(unittest.TestCase):
         self.assertEqual(
             len(
                 parsed_value_controller[4]
-                .get_call()[0]
-                .get_methods()
-                .get_call()[0]
+                .get_call()[1]
                 .get_methods()
                 .get_call()[1]
+                .get_methods()
+                .get_call()[0]
                 .get_methods()
                 .get_calls()
             ),
             2,
         )
+
         self.assertEqual(
             parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
+            .get_call()[1]
             .get_methods()
             .get_call()[1]
+            .get_methods()
+            .get_call()[0]
             .get_methods()
             .get_calls()[0]
-            .get_methods()
-            .get_name(),
-            "isBorrowed",
-        )
-        self.assertEqual(
-            parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
-            .get_methods()
-            .get_call()[1]
-            .get_methods()
-            .get_calls()[1]
             .get_methods()
             .get_name(),
             "findCopyBuku",
@@ -341,22 +380,22 @@ class TestParseJsonToObjectSeq(unittest.TestCase):
         self.assertEqual(
             len(
                 parsed_value_controller[4]
-                .get_call()[0]
-                .get_methods()
-                .get_call()[0]
+                .get_call()[1]
                 .get_methods()
                 .get_call()[1]
+                .get_methods()
+                .get_call()[0]
                 .get_arguments()
             ),
             1,
         )
         self.assertEqual(
             parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
+            .get_call()[1]
             .get_methods()
             .get_call()[1]
+            .get_methods()
+            .get_call()[0]
             .get_arguments()[0]
             .get_name(),
             "isbn",
@@ -364,77 +403,73 @@ class TestParseJsonToObjectSeq(unittest.TestCase):
 
         self.assertEqual(
             parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[1]
+            .get_methods()
             .get_call()[0]
+            .get_methods()
+            .get_calls()[1]
+            .get_methods()
+            .get_name(),
+            "isBorrowed",
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[1]
             .get_methods()
             .get_call()[1]
             .get_methods()
             .get_name(),
-            "showNotifikasiGagalPinjam",
+            "showNotifikasiBerhasilPinjam",
         )
+
         self.assertEqual(
             parsed_value_controller[4]
-            .get_call()[0]
+            .get_call()[1]
             .get_methods()
             .get_call()[2]
             .get_methods()
             .get_name(),
+            "showNotifikasiGagalPinjam",
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4]
+            .get_call()[1]
+            .get_methods()
+            .get_call()[2]
+            .get_condition(),
             "hasTanggungan",
         )
 
         self.assertEqual(
-            parsed_value_controller[4].get_call()[1].get_methods().get_name(),
+            len(
+                parsed_value_controller[4]
+                .get_call()[1]
+                .get_methods()
+                .get_call()[2]
+                .get_arguments()
+            ),
+            0,
+        )
+
+        self.assertEqual(
+            parsed_value_controller[4].get_call()[2].get_methods().get_name(),
             "showNotifikasiDataTidakValid",
         )
+
         self.assertEqual(
-            len(parsed_value_controller[4].get_call()[1].get_arguments()), 0
-        )
-        self.assertEqual(
-            len(parsed_value_controller[4].get_call()[1].get_methods().get_call()), 0
+            parsed_value_controller[4].get_call()[2].get_condition(),
+            "not isValid",
         )
 
         self.assertEqual(
-            parsed_value_controller[4].get_call()[2].get_methods().get_name(), "isValid"
-        )
-        self.assertEqual(
-            len(parsed_value_controller[4].get_call()[2].get_arguments()), 1
-        )
-        self.assertEqual(
-            len(parsed_value_controller[4].get_call()[2].get_methods().get_calls()), 0
-        )
-        self.assertEqual(
-            parsed_value_controller[4].get_call()[2].get_arguments()[0].get_name(),
-            "dataAnggota",
-        )
-
-        self.assertEqual(
-            len(parsed_value_controller[4].get_call()[0].get_methods().get_call()), 3
-        )
-        self.assertEqual(
-            parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[0]
-            .get_methods()
-            .get_name(),
-            "prosesPeminjamanTidakMemilikiTanggungan",
-        )
-        self.assertEqual(
-            parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[1]
-            .get_methods()
-            .get_name(),
-            "showNotifikasiGagalPinjam",
-        )
-        self.assertEqual(
-            parsed_value_controller[4]
-            .get_call()[0]
-            .get_methods()
-            .get_call()[2]
-            .get_methods()
-            .get_name(),
-            "hasTanggungan",
+            len(parsed_value_controller[4].get_call()[2].get_arguments()),
+            0,
         )
 
         self.assertEqual(

--- a/tests/test_parse_misc.py
+++ b/tests/test_parse_misc.py
@@ -55,11 +55,9 @@ class TestParseMisc(unittest.TestCase):
             self.parser.set_json(json_data)
             self.parser.parse()
             result = self.parser.get_method_call()
-            print(result)
             for edge in self.parser.get_edges():
                 start = edge["start"]
                 end = edge["end"]
                 key = (start, end)
-                print(result[key]["condition"])
                 if result[key]["condition"] is not None and key == (25, 14):
                     self.assertEqual(result[key]["condition"], "POST")


### PR DESCRIPTION
Parser for sequence diagram now process Method Call Object sequentially based on the order of occurence, not based on sorted id.