### PR TITLE
feat: logging in important functions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from app.model import ConvertRequest, DownloadRequest
 from app.models.elements import ClassObject, ModelsElements, ViewsElements
 from app.models.methods import ClassMethodObject
 from app.parse_json_to_object_seq import ParseJsonToObjectSeq
-from app.utils import remove_file
+from app.utils import logger, remove_file
 
 
 @asynccontextmanager
@@ -36,14 +36,18 @@ async def download_file(request: DownloadRequest) -> FileResponse:
     file = request.filename + request.type + ".py"
 
     if "/" in request.filename or "\\" in request.filename:
+        logger.warning(f"Bad filename: {request.filename}")
         raise HTTPException(status_code=400, detail="/ not allowed in file name")
 
     if os.path.exists(file):
+        logger.warning(f"File already exists: {file}")
+        # TODO: Add to metrics so we can know how many request actually face this problem
         raise HTTPException(status_code=400, detail="Please try again later")
 
     async with await anyio.open_file(file, "w") as f:
         await f.write(request.content)
-    print("done writing", file)
+
+    logger.info(f"Finished writing: {file}")
     return file
 
 
@@ -140,6 +144,7 @@ async def convert(
         )
 
     except ValueError as ex:
+        logger.warning("Error occured at parsing: " + str(ex).replace("\n", " "))
         raise HTTPException(status_code=422, detail=str(ex))
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -145,7 +145,9 @@ async def convert(
 
     except ValueError as ex:
         ex_str = str(ex)
-        logger.warning("Error occured at parsing: " + ex_str.replace("\n", " "))
+        logger.warning(
+            "Error occurred at parsing: " + ex_str.replace("\n", " "), exc_info=True
+        )
         raise HTTPException(status_code=422, detail=ex_str)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -144,8 +144,9 @@ async def convert(
         )
 
     except ValueError as ex:
-        logger.warning("Error occured at parsing: " + str(ex).replace("\n", " "))
-        raise HTTPException(status_code=422, detail=str(ex))
+        ex_str = str(ex)
+        logger.warning("Error occured at parsing: " + ex_str.replace("\n", " "))
+        raise HTTPException(status_code=422, detail=ex_str)
 
 
 def check_duplicate(
@@ -157,13 +158,9 @@ def check_duplicate(
     if not class_object:
         return duplicate_class_method_checker
     for class_method_object in class_objects[class_object_name].get_methods():
-        if (
-            class_object_name,
-            class_method_object.get_name(),
-        ) in duplicate_class_method_checker:
-            duplicate_class_method_checker[
-                (class_object_name, class_method_object.get_name())
-            ] = class_method_object
+        key = (class_object_name, class_method_object.get_name())
+        if key in duplicate_class_method_checker:
+            duplicate_class_method_checker[key] = class_method_object
         else:
             raise ValueError(
                 f"Cannot call class '{class_object_name}' objects not defined in Class Diagram!"

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,11 +1,13 @@
+import logging
 import os
 import re
 from keyword import iskeyword
 from typing import Any
 
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, TemplateNotFound
 
 env = Environment(loader=PackageLoader("app"))
+logger = logging.getLogger("uvicorn.error")
 
 
 def remove_file(path: str) -> None:
@@ -20,8 +22,12 @@ def render_template(template_name: str, context: dict[str, Any]) -> str:
     try:
         template = env.get_template(template_name)
         return template.render(context)
-    except Exception as e:
-        print(f"Error rendering template {template_name}: {e}")
+    except TemplateNotFound as e:  # Somehow the template can't be found
+        logger.error(f"Template not found: {e}")
+        # TODO: Maybe send alert to us
+        return ""
+    except Exception as e:  # All other cases
+        logger.warning(f"An error occured: {e}")
         return ""
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       - "8000:8000"
     networks:
       - monitoring
+    logging:
+      options:
+        max-size: "50mb"
+        max-file: "4"
     deploy:
       resources:
         limits:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,142 @@
+import logging
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from pytest import LogCaptureFixture
+
+from app.main import app, download_file
+from app.model import DownloadRequest
+from app.utils import render_template
+
+CUR_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_uvicorn_error_logger_warning_when_convert_raises_value_err(
+    caplog: LogCaptureFixture,
+):
+    client = TestClient(app)
+    payload = {"filename": ["test"], "content": [['{"diagram": "ClassDiagram"}']]}
+
+    with caplog.at_level(logging.WARNING, "uvicorn.error"):
+        with patch("app.main.ModelsElements") as mock_models:
+            mock_instance_models = mock_models.return_value
+            mock_instance_models.parse.side_effect = Mock(
+                side_effect=ValueError("some error")
+            )
+            client.post("/convert", json=payload)
+
+        assert len(caplog.records) == 1
+        assert (
+            "uvicorn.error",
+            logging.WARNING,
+            "Error occured at parsing: some error",
+        ) in caplog.record_tuples
+
+
+def test_uvicorn_error_logger_no_warning_when_convert_success(
+    caplog: LogCaptureFixture,
+):
+    client = TestClient(app)
+    with open(os.path.join(CUR_DIR, "test_input.txt")) as f:
+        content = f.read().strip()
+    payload = {"filename": ["test"], "content": [[content]]}
+
+    with caplog.at_level(logging.WARNING, "uvicorn.error"):
+        client.post("/convert", json=payload)
+        assert len(caplog.records) == 0
+
+
+@pytest.mark.asyncio
+async def test_uvicorn_error_logger_warning_when_download_file_bad_filename(
+    caplog: LogCaptureFixture,
+):
+    req = DownloadRequest(filename="/etc/passwd", content="abcd", type="abcd")
+    with caplog.at_level(logging.WARNING, "uvicorn.error"):
+        try:
+            await download_file(req)
+        except HTTPException:
+            # already tested in test_main.py
+            pass
+
+        assert len(caplog.records) == 1
+        assert (
+            "uvicorn.error",
+            logging.WARNING,
+            "Bad filename: /etc/passwd",
+        ) in caplog.record_tuples
+
+
+@pytest.mark.asyncio
+async def test_uvicorn_error_logger_warning_when_download_file_file_exists(
+    caplog: LogCaptureFixture,
+):
+    req = DownloadRequest(filename="abcd", content="abcd", type="abcd")
+    with caplog.at_level(logging.WARNING, "uvicorn.error"):
+        try:
+            with patch("app.main.os.path.exists") as mock_exists:
+                mock_exists.return_value = True
+                await download_file(req)
+        except HTTPException:
+            # already tested in test_main.py
+            pass
+
+        assert len(caplog.records) == 1
+        assert (
+            "uvicorn.error",
+            logging.WARNING,
+            "File already exists: abcdabcd.py",
+        ) in caplog.record_tuples
+
+
+@pytest.mark.asyncio
+async def test_uvicorn_error_logger_info_when_download_file_success(
+    caplog: LogCaptureFixture,
+):
+    req = DownloadRequest(filename="abcd", content="abcd", type="abcd")
+    with caplog.at_level(logging.INFO, "uvicorn.error"):
+        with patch("app.main.anyio.open_file") as mock_anyio:
+            mock_anyio.return_value = AsyncMock()
+            await download_file(req)
+
+        assert len(caplog.records) == 1
+        assert (
+            "uvicorn.error",
+            logging.INFO,
+            "Finished writing: abcdabcd.py",
+        ) in caplog.record_tuples
+
+
+def test_uvicorn_error_logger_error_when_template_not_found(
+    caplog: LogCaptureFixture,
+):
+    with caplog.at_level(logging.ERROR, "uvicorn.error"):
+        render_template("a", {})
+
+        assert len(caplog.records) == 1
+        assert (
+            "uvicorn.error",
+            logging.ERROR,
+            "Template not found: a",
+        ) in caplog.record_tuples
+
+
+def test_uvicorn_error_logger_warning_when_unexpected_exception(
+    caplog: LogCaptureFixture,
+):
+    with patch("app.utils.env.get_template") as mock_template:
+        mock_template.return_value = Mock()
+        mock_template.return_value.render.side_effect = Mock(
+            side_effect=KeyError("somehow key error occured")
+        )
+        with caplog.at_level(logging.WARNING, "uvicorn.error"):
+            render_template("models.py.j2", {})
+
+            assert len(caplog.records) == 1
+            assert (
+                "uvicorn.error",
+                logging.WARNING,
+                "An error occured: 'somehow key error occured'",
+            ) in caplog.record_tuples

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -32,7 +32,7 @@ def test_uvicorn_error_logger_warning_when_convert_raises_value_err(
         assert (
             "uvicorn.error",
             logging.WARNING,
-            "Error occured at parsing: some error",
+            "Error occurred at parsing: some error",
         ) in caplog.record_tuples
 
 


### PR DESCRIPTION
- Added logging to the convert endpoint, download file function, and render template function as those seems to be the backbone of our business process, so knowing if something went wrong there will be beneficial for us.
- Slightly refactored the `check_duplicate` method on `main.py` to lessen unnecessary function calls.
- Limited log file size to 50MB and a maximum of 4 log files. I think this should be enough for our use case for the time being and considering the storage limitation, but feel free to comment on it if you feel like its not enough.

I am thinking of also adding some of the log results to prometheus as metrics, but am still looking at ways to go about it as well as test it, so it is not in this PR.