### PR TITLE
EXTRA 5: Use tempfile instead of writing files to current directory

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import MagicMock, Mock, patch
 
-import anyio
 import pytest
 from fastapi.testclient import TestClient
 
@@ -141,9 +140,6 @@ async def test_convert_endpoint_valid_content_class_diagram():
             "content": [['{"content"}']],
             "project_name": "file1",
         }
-
-        async with await anyio.open_file("file1.zip", "w") as f:
-            await f.write("")
 
         # Send the request to the endpoint
         response = client.post("/convert", json=payload)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -147,6 +147,7 @@ async def test_convert_endpoint_valid_content_class_diagram():
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
+        assert "file1.zip" in response.headers["content-disposition"]
 
 
 @pytest.mark.asyncio
@@ -206,8 +207,9 @@ async def test_convert_endpoint_class_diagram():
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
+        assert "file1.zip" in response.headers["content-disposition"]
         assert response.content.startswith(
-            b"PK"
+            b"PK\x03\x04"
         )  # Check that the response is a zip file
 
 
@@ -267,8 +269,9 @@ async def test_convert_endpoint_sequence_diagram():
         # Validate the response
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
+        assert "file1.zip" in response.headers["content-disposition"]
         assert response.content.startswith(
-            b"PK"
+            b"PK\x03\x04"
         )  # Check that the response is a zip file
 
 
@@ -357,6 +360,7 @@ async def test_convert_endpoint_valid_sequence_diagram():
         mock_check_duplicate.assert_called()
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
+        assert "file1.zip" in response.headers["content-disposition"]
 
 
 @pytest.mark.asyncio
@@ -393,6 +397,7 @@ async def test_convert_endpoint_valid_multiple_file_content():
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
+        assert "file1.zip" in response.headers["content-disposition"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of MOT-98 and issue #55 
- Modified all zip file writing on current directory to use temp files instead.
- Added necessary clean ups for the temp zip file.
- Added some more constraint on test_main to see that the returned filename is not the temp filename, but the project name.