### PR TITLE
Pbi 7 1 generate models file

### DIFF
--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -4,7 +4,7 @@ from abc import ABC
 from io import StringIO
 from typing import Optional
 
-from app.utils import is_valid_python_identifier
+from app.utils import is_valid_python_identifier, to_camel_case, to_pascal_case
 
 from .methods import ClassMethodObject
 from .properties import FieldObject
@@ -72,8 +72,10 @@ class ClassObject:
         """Returns a dictionary with the class name, parent class name, fields and relationships
         for the Spring Boot template."""
         ctx = {
-            "name": self.get_name(),
-            "parent": self.__parent.get_name() if self.__parent else None,
+            "name": to_pascal_case(self.get_name()),
+            "parent": to_pascal_case(self.__parent.get_name())
+            if self.__parent
+            else None,
             "fields": [],
             "relationships": [],
         }
@@ -204,7 +206,7 @@ class OneToOneRelationshipObject(AbstractRelationshipObject):
         target = self.get_target_class().get_name()
         rel_type = f'@OneToOne(mappedBy="{source}")\n'
         join = f"@JoinColumn(name = '{source}', referencedColumnName = 'id')\n"
-        var = f"private {target} {target.lower()};"
+        var = f"private {to_pascal_case(target)} {to_camel_case(target)};"
         return {"name": var, "type": rel_type, "join": join}
 
 
@@ -240,7 +242,7 @@ class ManyToOneRelationshipObject(AbstractRelationshipObject):
         else:
             rel_type = "@ManyToOne\n"
             join = f"@JoinColumn(name = '{source}', referencedColumnName = 'id')\n"
-        var = f"private {target} {target.lower()};"
+        var = f"private {to_pascal_case(target)} {to_camel_case(target)};"
         return {"name": var, "type": rel_type, "join": join}
 
 
@@ -270,5 +272,5 @@ class ManyToManyRelationshipObject(AbstractRelationshipObject):
         join += f'\tname = "{source}_{target.lower()}",\n'
         join += f'\tjoinColumns = @JoinColumn(name = "{source}_id")\n'
         join += f'\tinverseJoinColumn = @JoinColumn(name = "{target.lower()}_id")\n)\n'
-        var = f"private List<{target}> listOf{target.title()}s;"
+        var = f"private List<{to_pascal_case(target)}> listOf{to_pascal_case(target)}s;"
         return {"name": var, "type": rel_type, "join": join}

--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -89,16 +89,9 @@ class ClassObject:
     def __str__(self) -> str:
         """__str__ method for debugging purposes."""
         return (
-            f"Class Object:\n\tname: {self.__name}\n\tparent: "
-            f"{self.__parent.get_name() if self.__parent else None}"
-            f"\n\tfields: {[field.get_name() for field in self.__fields]}"
-            f"\n\tmethods: {[method.get_name() for method in self.__methods]}"
-            f"\n\trelationships: {
-                [
-                    relationship.get_target_class().get_name()
-                    for relationship in self.__relationships
-                ]
-            }"
+            f"Class Object:\n\tname: {self.__name}\n\tparent: {self.__parent}"
+            f"\n\tfields:{self.__fields}\n\t methods: {self.__methods}"
+            f"\n\trelationships: {self.__relationships}"
         )
 
     def set_name(self, name: str):

--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -201,10 +201,10 @@ class OneToOneRelationshipObject(AbstractRelationshipObject):
 
     def to_springboot_models_template(self) -> dict[str, str]:
         source = self.get_source_class().get_name().lower()
-        name = self.get_target_class().get_name()
+        target = self.get_target_class().get_name()
         rel_type = f'@OneToOne(mappedBy="{source}")\n'
         join = f"@JoinColumn(name = '{source}', referencedColumnName = 'id')\n"
-        var = f"private {name} {name.lower()};"
+        var = f"private {target} {target.lower()};"
         return {"name": var, "type": rel_type, "join": join}
 
 
@@ -234,13 +234,13 @@ class ManyToOneRelationshipObject(AbstractRelationshipObject):
 
     def to_springboot_models_template(self) -> dict[str, str]:
         source = self.get_source_class().get_name().lower()
-        name = self.get_target_class().get_name()
+        target = self.get_target_class().get_name()
         if self.get_source_class_own_amount == "1":
             rel_type = f'@OneToMany(mappedBy="{source}")\n'
         else:
             rel_type = "@ManyToOne\n"
             join = f"@JoinColumn(name = '{source}', referencedColumnName = 'id')\n"
-        var = f"private {name} {name.lower()};"
+        var = f"private {target} {target.lower()};"
         return {"name": var, "type": rel_type, "join": join}
 
 
@@ -264,11 +264,11 @@ class ManyToManyRelationshipObject(AbstractRelationshipObject):
 
     def to_springboot_models_template(self) -> dict[str, str]:
         source = self.get_source_class().get_name().lower()
-        name = self.get_target_class().get_name()
+        target = self.get_target_class().get_name()
         rel_type = "@ManyToMany\n"
         join = "@JoinTable(\n"
-        join += f'\tname = "{source}_{name.lower()}",\n'
+        join += f'\tname = "{source}_{target.lower()}",\n'
         join += f'\tjoinColumns = @JoinColumn(name = "{source}_id")\n'
-        join += f'\tinverseJoinColumn = @JoinColumn(name = "{name.lower()}_id")\n)\n'
-        var = f"private List<{name}> listOf{name.title()}s;"
+        join += f'\tinverseJoinColumn = @JoinColumn(name = "{target.lower()}_id")\n)\n'
+        var = f"private List<{target}> listOf{target.title()}s;"
         return {"name": var, "type": rel_type, "join": join}

--- a/app/models/elements.py
+++ b/app/models/elements.py
@@ -132,7 +132,7 @@ class ModelsElements(FileElements):
             return files
         except Exception as e:
             logger.error(f"Error rendering template: {e}")
-            return ""
+            return {}
 
 
 class ViewsElements(FileElements):

--- a/app/models/elements.py
+++ b/app/models/elements.py
@@ -106,6 +106,34 @@ class ModelsElements(FileElements):
             logger.error(f"Error rendering template: {e}")
             return ""
 
+    def print_springboot_style(self, project_name: str) -> dict[str, str]:
+        """
+        Returns a dictionary containing the class name as the key and
+        the rendered model files as the value
+
+        Example:
+
+        {
+            "Class1": "Rendered Jinja template for Class1",
+            "Class2": "Rendered Jinja template for Class2",
+            ...
+        }
+
+        """
+        try:
+            files = {}
+            for model_class in self.__classes:
+                ctx = model_class.to_models_springboot_context()
+                ctx["project_name"] = project_name
+
+                files[model_class.get_name()] = render_template(
+                    "springboot/model.j2", context=ctx
+                )
+            return files
+        except Exception as e:
+            logger.error(f"Error rendering template: {e}")
+            return ""
+
 
 class ViewsElements(FileElements):
     """

--- a/app/models/properties.py
+++ b/app/models/properties.py
@@ -70,6 +70,25 @@ class FieldObject:
         "Decimal": "models.DecimalField(max_digits=10, decimal_places=2)",
     }
 
+    SPRING_TYPE_MAPPING = {
+        "boolean": "boolean",
+        "String": "String",
+        "str": "String",
+        "int": "Integer",
+        "bool": "boolean",
+        "integer": "Integer",
+        "float": "float",
+        "double": "double",
+        "Date": "LocalDate",
+        "DateTime": "LocalDateTime",
+        "Time": "LocalTime",
+        "Text": "String",
+        "Email": "String",
+        "URL": "String",
+        "UUID": "UUID",
+        "Decimal": "BigDecimal",
+    }
+
     def __init__(self):
         self.__name: str = ""
         self.__type: Optional[TypeObject] = None
@@ -106,6 +125,14 @@ class FieldObject:
             "name": self.__name,
             "type": "models.CharField(max_length=255)",
         }  # Default fallback
+
+    def to_springboot_models_template(self) -> str:
+        field_type = self.__type.to_models_code().lower()
+
+        for key, value in self.SPRING_TYPE_MAPPING.items():
+            if key.lower() in field_type:
+                return {"name": self.__name, "type": value}
+        return {"name": self.__name, "type": "String"}  # Default fallback
 
 
 class ParameterObject:

--- a/app/models/properties.py
+++ b/app/models/properties.py
@@ -128,7 +128,7 @@ class FieldObject:
             "type": MODELS_CHARFIELD,
         }  # Default fallback
 
-    def to_springboot_models_template(self) -> str:
+    def to_springboot_models_template(self) -> dict[str, str]:
         field_type = self.__type.to_models_code().lower()
 
         for key, value in self.SPRING_TYPE_MAPPING.items():

--- a/app/parse_class_pattern/parse_relationship_strategy.py
+++ b/app/parse_class_pattern/parse_relationship_strategy.py
@@ -8,7 +8,11 @@ from app.models.diagram import (
 
 class RelationshipStrategy:
     def create_relationship(
-        self, edge: dict, class_from_id: ClassObject, class_to_id: ClassObject
+        self,
+        edge: dict,
+        class_from_id: ClassObject,
+        class_to_id: ClassObject,
+        bidirectional: bool = False,
     ) -> None:
         raise NotImplementedError(
             "RelationshipStrategy does not implement create_relationship"
@@ -17,7 +21,11 @@ class RelationshipStrategy:
 
 class OneToOneStrategy(RelationshipStrategy):
     def create_relationship(
-        self, edge: dict, class_from_id: ClassObject, class_to_id: ClassObject
+        self,
+        edge: dict,
+        class_from_id: ClassObject,
+        class_to_id: ClassObject,
+        bidirectional: bool = False,
     ) -> None:
         ro = OneToOneRelationshipObject()
         ro.set_source_class(class_from_id)
@@ -25,11 +33,22 @@ class OneToOneStrategy(RelationshipStrategy):
         ro.set_source_class_own_amount(edge["startLabel"])
         ro.set_target_class_own_amount(edge["endLabel"])
         class_from_id.add_relationship(ro)
+        if bidirectional:
+            ro2 = OneToOneRelationshipObject()
+            ro2.set_source_class(class_to_id)
+            ro2.set_target_class(class_from_id)
+            ro2.set_source_class_own_amount(edge["endLabel"])
+            ro2.set_target_class_own_amount(edge["startLabel"])
+            class_to_id.add_relationship(ro2)
 
 
 class ManyToOneStrategy(RelationshipStrategy):
     def create_relationship(
-        self, edge: dict, class_from_id: ClassObject, class_to_id: ClassObject
+        self,
+        edge: dict,
+        class_from_id: ClassObject,
+        class_to_id: ClassObject,
+        bidirectional: bool = False,
     ) -> None:
         ro = ManyToOneRelationshipObject()
         start_condition = (
@@ -44,17 +63,35 @@ class ManyToOneStrategy(RelationshipStrategy):
             ro.set_source_class(class_from_id)
             ro.set_target_class(class_to_id)
             class_from_id.add_relationship(ro)
+            if bidirectional:
+                ro2 = ManyToOneRelationshipObject()
+                ro2.set_source_class_own_amount(edge["endLabel"])
+                ro2.set_target_class_own_amount(edge["startLabel"])
+                ro2.set_source_class(class_to_id)
+                ro2.set_target_class(class_from_id)
+                class_to_id.add_relationship(ro2)
         else:
             ro.set_source_class_own_amount(edge["endLabel"])
             ro.set_target_class_own_amount(edge["startLabel"])
             ro.set_source_class(class_to_id)
             ro.set_target_class(class_from_id)
             class_to_id.add_relationship(ro)
+            if bidirectional:
+                ro2 = ManyToOneRelationshipObject()
+                ro2.set_source_class_own_amount(edge["startLabel"])
+                ro2.set_target_class_own_amount(edge["endLabel"])
+                ro2.set_source_class(class_from_id)
+                ro2.set_target_class(class_to_id)
+                class_from_id.add_relationship(ro2)
 
 
 class ManyToManyStrategy(RelationshipStrategy):
     def create_relationship(
-        self, edge: dict, class_from_id: ClassObject, class_to_id: ClassObject
+        self,
+        edge: dict,
+        class_from_id: ClassObject,
+        class_to_id: ClassObject,
+        bidirectional: bool = False,
     ) -> None:
         ro = ManyToManyRelationshipObject()
         ro.set_source_class(class_from_id)
@@ -62,3 +99,10 @@ class ManyToManyStrategy(RelationshipStrategy):
         ro.set_source_class_own_amount(edge["startLabel"])
         ro.set_target_class_own_amount(edge["endLabel"])
         class_from_id.add_relationship(ro)
+        if bidirectional:
+            ro2 = ManyToManyRelationshipObject()
+            ro2.set_source_class(class_to_id)
+            ro2.set_target_class(class_from_id)
+            ro2.set_source_class_own_amount(edge["endLabel"])
+            ro2.set_target_class_own_amount(edge["startLabel"])
+            class_to_id.add_relationship(ro2)

--- a/app/parse_json_to_object_class.py
+++ b/app/parse_json_to_object_class.py
@@ -55,7 +55,9 @@ class ParseJsonToObjectClass:
 
         return self.__classes
 
-    def parse_relationships(self, classes: list[ClassObject]) -> list[ClassObject]:
+    def parse_relationships(
+        self, classes: list[ClassObject], bidirectional: bool = False
+    ) -> list[ClassObject]:
         edges = self.__json["edges"]
 
         for edge in edges:
@@ -75,7 +77,9 @@ class ParseJsonToObjectClass:
                 )
 
             strategy = self.__determine_strategy(edge)
-            strategy.create_relationship(edge, class_from_id, class_to_id)
+            strategy.create_relationship(
+                edge, class_from_id, class_to_id, bidirectional
+            )
 
         return classes
 

--- a/app/templates/springboot/model.j2
+++ b/app/templates/springboot/model.j2
@@ -1,0 +1,40 @@
+package {{ project_name }}.model;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+{%- if parent %}
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+{%- else %}
+{% endif -%}
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class {{ name }}{% if parent %} extends {{ parent }}{% endif %} {
+    {% if not parent %}
+    @Id
+    private String id = UUID.randomUUID().toString();
+    {% endif -%}
+
+    {%+ for field in fields %}
+    private {{field.type}} {{ field.name }};
+    {% endfor %}
+
+    {%- for relationship in relationships %}
+    {{ relationship.type }}
+    {%- if relationship.join -%}
+    {{ relationship.join }}
+    {%- else -%}
+    {%- endif -%}
+    {{ relationship.name }}
+    {% endfor -%}
+}

--- a/app/templates/springboot/model.j2
+++ b/app/templates/springboot/model.j2
@@ -16,8 +16,7 @@ import java.util.UUID;
 @Setter
 {%- if parent %}
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-{%- else %}
-{% endif -%}
+{%- endif -%}
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class {{ name }}{% if parent %} extends {{ parent }}{% endif %} {
     {% if not parent %}
@@ -33,7 +32,6 @@ public class {{ name }}{% if parent %} extends {{ parent }}{% endif %} {
     {{ relationship.type }}
     {%- if relationship.join -%}
     {{ relationship.join }}
-    {%- else -%}
     {%- endif -%}
     {{ relationship.name }}
     {% endfor -%}

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -145,6 +145,73 @@ listOfTargetclass = models.ManyToManyField('TargetClass')\n\tpass\n\n\n"
         model.set_is_public(False)
         self.assertFalse(model.get_is_public())
 
+    def test_to_models_springboot_context_positive(self):
+        self.class_object.set_name("Test Class")
+        parent_class = ClassObject()
+        parent_class.set_name("Parent Class")
+        self.class_object.set_parent(parent_class)
+
+        field = FieldObject()
+        field_type = TypeObject()
+        field.set_name("field1")
+        field_type.set_name("boolean")
+        field.set_type(field_type)
+        self.class_object.add_field(field)
+
+        relationship = OneToOneRelationshipObject()
+        target_class = ClassObject()
+        target_class.set_name("Target Class")
+        relationship.set_source_class(self.class_object)
+        relationship.set_target_class(target_class)
+        self.class_object.add_relationship(relationship)
+        target_class.add_relationship(relationship)
+
+        context = self.class_object.to_models_springboot_context()
+
+        expected_context = {
+            "name": "TestClass",
+            "parent": "ParentClass",
+            "fields": [field.to_springboot_models_template()],
+            "relationships": [relationship.to_springboot_models_template()],
+        }
+
+        self.assertEqual(context, expected_context)
+
+    def test_to_models_springboot_context_no_parent(self):
+        self.class_object.set_name("Test Class")
+        context = self.class_object.to_models_springboot_context()
+
+        expected_context = {
+            "name": "TestClass",
+            "parent": None,
+            "fields": [],
+            "relationships": [],
+        }
+
+        self.assertEqual(context, expected_context)
+
+    def test_to_models_springboot_context_edge_case_invalid_field(self):
+        self.class_object.set_name("Test Class")
+        context = self.class_object.to_models_springboot_context()
+        expected_context = {
+            "name": "TestClass",
+            "parent": None,
+            "fields": [],
+            "relationships": [],
+        }
+        self.assertEqual(context, expected_context)
+
+    def test_to_models_springboot_context_edge_case_invalid_relationship(self):
+        self.class_object.set_name("Test Class")
+        context = self.class_object.to_models_springboot_context()
+        expected_context = {
+            "name": "TestClass",
+            "parent": None,
+            "fields": [],
+            "relationships": [],
+        }
+        self.assertEqual(context, expected_context)
+
 
 class TestAbstractRelationshipObject(unittest.TestCase):
     def setUp(self):
@@ -287,6 +354,92 @@ class TestManyToManyRelationshipObject(unittest.TestCase):
         self.assertIsInstance(
             self.many_to_many_relationship, AbstractRelationshipObject
         )
+
+
+class TestToSpringbootModelsTemplate(unittest.TestCase):
+    def setUp(self):
+        self.source_class = ClassObject()
+        self.target_class = ClassObject()
+        self.source_class.set_name("Source Class")
+        self.target_class.set_name("Target Class")
+
+    def test_one_to_one_relationship_positive(self):
+        relationship = OneToOneRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        expected_output = {
+            "name": "private TargetClass targetClass;",
+            "type": '@OneToOne(mappedBy="source_class")\n',
+            "join": "@JoinColumn(name = 'source_class', referencedColumnName = 'id')\n",
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
+    def test_many_to_one_relationship_positive(self):
+        relationship = ManyToOneRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        relationship.set_source_class_own_amount("1")
+        expected_output = {
+            "name": "private TargetClass targetClass;",
+            "type": '@OneToMany(mappedBy="source_class")\n',
+            "join": None,
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
+    def test_many_to_one_relationship_positive_2(self):
+        relationship = ManyToOneRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        relationship.set_source_class_own_amount("*")
+        expected_output = {
+            "name": "private TargetClass targetClass;",
+            "type": "@ManyToOne\n",
+            "join": "@JoinColumn(name = 'source_class', referencedColumnName = 'id')\n",
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
+    def test_many_to_many_relationship_positive(self):
+        relationship = ManyToManyRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        expected_output = {
+            "name": "private List<TargetClass> listOfTargetClasss;",
+            "type": "@ManyToMany\n",
+            "join": "@JoinTable(\n"
+            '\tname = "source_class_target_class",\n'
+            '\tjoinColumns = @JoinColumn(name = "source_class_id")\n'
+            '\tinverseJoinColumn = @JoinColumn(name = "target_class_id")\n)\n',
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
+    def test_one_to_one_relationship_edge_case_empty_names(self):
+        self.source_class.set_name("")
+        self.target_class.set_name("")
+        relationship = OneToOneRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        expected_output = {
+            "name": "private  ;",
+            "type": '@OneToOne(mappedBy="")\n',
+            "join": "@JoinColumn(name = '', referencedColumnName = 'id')\n",
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
+    def test_many_to_many_relationship_edge_case_empty_names(self):
+        self.source_class.set_name("")
+        self.target_class.set_name("")
+        relationship = ManyToManyRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        expected_output = {
+            "name": "private List<> listOfs;",
+            "type": "@ManyToMany\n",
+            "join": "@JoinTable(\n"
+            '\tname = "_",\n'
+            '\tjoinColumns = @JoinColumn(name = "_id")\n'
+            '\tinverseJoinColumn = @JoinColumn(name = "_id")\n)\n',
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
 
 
 if __name__ == "__main__":

--- a/tests/test_model_springboot.py
+++ b/tests/test_model_springboot.py
@@ -1,0 +1,139 @@
+import unittest
+from unittest import mock
+
+from app.models.diagram import ClassObject
+from app.models.elements import ModelsElements
+from app.models.properties import FieldObject, TypeObject
+
+
+class TestModelsElementsSpringBootStyle(unittest.TestCase):
+    def setUp(self):
+        self.models = ModelsElements("models.py")
+
+    def test_print_springboot_style_positive_case(self):
+        """Test: Positive case where valid ClassObjects are converted to Spring Boot style."""
+        class_obj_1 = ClassObject()
+        class_obj_1.set_name("Class1")
+        class_obj_1.to_models_springboot_context = mock.Mock(
+            return_value={"name": "Class1", "fields": []}
+        )
+
+        class_obj_2 = ClassObject()
+        class_obj_2.set_name("Class2")
+        class_obj_2.to_models_springboot_context = mock.Mock(
+            return_value={"name": "Class2", "fields": []}
+        )
+
+        self.models.add_class(class_obj_1)
+        self.models.add_class(class_obj_2)
+
+        with mock.patch("app.models.elements.render_template") as mock_render_template:
+            mock_render_template.side_effect = lambda template, context: (
+                f"Rendered {context['name']}"
+            )
+
+            result = self.models.print_springboot_style("test_project")
+
+            self.assertEqual(len(result), 2)
+            self.assertIn("Class1", result)
+            self.assertIn("Class2", result)
+            self.assertEqual(result["Class1"], "Rendered Class1")
+            self.assertEqual(result["Class2"], "Rendered Class2")
+
+    def test_print_springboot_style_negative_case_render_error(self):
+        """Test: Negative case where rendering the template raises an exception."""
+        class_obj = ClassObject()
+        class_obj.set_name("Class1")
+        class_obj.to_models_springboot_context = mock.Mock(
+            return_value={"name": "Class1", "fields": []}
+        )
+
+        self.models.add_class(class_obj)
+
+        with mock.patch(
+            "app.models.elements.render_template",
+            side_effect=Exception("Render error"),
+        ):
+            result = self.models.print_springboot_style("test_project")
+
+            self.assertEqual(result, "")
+
+    def test_print_springboot_style_edge_case_no_classes(self):
+        """Test: Edge case where no classes are added to the ModelsElements."""
+        result = self.models.print_springboot_style("test_project")
+        self.assertEqual(result, {})
+
+    def test_print_springboot_style_edge_case_empty_project_name(self):
+        """Test: Edge case where the project name is an empty string."""
+        class_obj = ClassObject()
+        class_obj.set_name("Class1")
+        class_obj.to_models_springboot_context = mock.Mock(
+            return_value={"name": "Class1", "fields": []}
+        )
+
+        self.models.add_class(class_obj)
+
+        with mock.patch("app.models.elements.render_template") as mock_render_template:
+            mock_render_template.side_effect = lambda template, context: (
+                f"Rendered {context['name']}"
+            )
+
+            result = self.models.print_springboot_style("")
+
+            self.assertEqual(len(result), 1)
+            self.assertIn("Class1", result)
+            self.assertEqual(result["Class1"], "Rendered Class1")
+
+
+class TestFieldObjectSpringBootTemplate(unittest.TestCase):
+    def setUp(self):
+        self.field_object = FieldObject()
+
+    def test_to_springboot_models_template_positive(self):
+        self.field_object.set_name("test_field")
+        type_obj = TypeObject()
+        type_obj.set_name("integer")
+        self.field_object.set_type(type_obj)
+        expected_output = {"name": "test_field", "type": "Integer"}
+        self.assertEqual(
+            self.field_object.to_springboot_models_template(), expected_output
+        )
+
+    def test_to_springboot_models_template_default_fallback(self):
+        self.field_object.set_name("test_field")
+        type_obj = TypeObject()
+        type_obj.set_name("unknown_type")
+        self.field_object.set_type(type_obj)
+        expected_output = {"name": "test_field", "type": "String"}
+        self.assertEqual(
+            self.field_object.to_springboot_models_template(), expected_output
+        )
+
+    def test_to_springboot_models_template_edge_case_empty_name(self):
+        self.field_object.set_name("")
+        type_obj = TypeObject()
+        type_obj.set_name("boolean")
+        self.field_object.set_type(type_obj)
+        expected_output = {"name": "", "type": "boolean"}
+        self.assertEqual(
+            self.field_object.to_springboot_models_template(), expected_output
+        )
+
+    def test_to_springboot_models_template_edge_case_empty_type(self):
+        self.field_object.set_name("test_field")
+        type_obj = TypeObject()
+        type_obj.set_name("")
+        self.field_object.set_type(type_obj)
+        expected_output = {"name": "test_field", "type": "String"}
+        self.assertEqual(
+            self.field_object.to_springboot_models_template(), expected_output
+        )
+
+    def test_to_springboot_models_template_negative_no_name_set(self):
+        type_obj = TypeObject()
+        type_obj.set_name("float")
+        self.field_object.set_type(type_obj)
+        expected_output = {"name": "", "type": "float"}
+        self.assertEqual(
+            self.field_object.to_springboot_models_template(), expected_output
+        )

--- a/tests/test_model_springboot.py
+++ b/tests/test_model_springboot.py
@@ -56,7 +56,7 @@ class TestModelsElementsSpringBootStyle(unittest.TestCase):
         ):
             result = self.models.print_springboot_style("test_project")
 
-            self.assertEqual(result, "")
+            self.assertEqual(result, {})
 
     def test_print_springboot_style_edge_case_no_classes(self):
         """Test: Edge case where no classes are added to the ModelsElements."""

--- a/tests/test_parse_class_pattern/test_strategy.py
+++ b/tests/test_parse_class_pattern/test_strategy.py
@@ -48,5 +48,67 @@ class TestRelationshipStrategy(unittest.TestCase):
         )
 
 
+class TestRelationshipStrategyBidirectional(unittest.TestCase):
+    def test_one_to_one_bidirectional(self):
+        strategy = OneToOneStrategy()
+        edge = {"startLabel": "1", "endLabel": "1"}
+        class_from = ClassObject()
+        class_to = ClassObject()
+
+        strategy.create_relationship(edge, class_from, class_to, bidirectional=True)
+        self.assertEqual(len(class_from._ClassObject__relationships), 1)
+        self.assertEqual(
+            class_from._ClassObject__relationships[0].get_target_class(), class_to
+        )
+        self.assertEqual(
+            class_to._ClassObject__relationships[0].get_target_class(), class_from
+        )
+
+    def test_many_to_one_bidirectional(self):
+        strategy = ManyToOneStrategy()
+        edge = {"startLabel": "*", "endLabel": "1"}
+        class_from = ClassObject()
+        class_to = ClassObject()
+
+        strategy.create_relationship(edge, class_from, class_to, bidirectional=True)
+        self.assertEqual(len(class_from._ClassObject__relationships), 1)
+        self.assertEqual(
+            class_from._ClassObject__relationships[0].get_target_class(), class_to
+        )
+        self.assertEqual(
+            class_to._ClassObject__relationships[0].get_target_class(), class_from
+        )
+
+    def test_one_to_many_bidirectional(self):
+        strategy = ManyToOneStrategy()
+        edge = {"startLabel": "*", "endLabel": "1"}
+        class_from = ClassObject()
+        class_to = ClassObject()
+
+        strategy.create_relationship(edge, class_from, class_to, bidirectional=True)
+        self.assertEqual(len(class_from._ClassObject__relationships), 1)
+        self.assertEqual(
+            class_from._ClassObject__relationships[0].get_target_class(), class_to
+        )
+        self.assertEqual(
+            class_to._ClassObject__relationships[0].get_target_class(), class_from
+        )
+
+    def test_many_to_many_bidirectional(self):
+        strategy = ManyToManyStrategy()
+        edge = {"startLabel": "*", "endLabel": "*"}
+        class_from = ClassObject()
+        class_to = ClassObject()
+
+        strategy.create_relationship(edge, class_from, class_to, bidirectional=True)
+        self.assertEqual(len(class_from._ClassObject__relationships), 1)
+        self.assertEqual(
+            class_from._ClassObject__relationships[0].get_target_class(), class_to
+        )
+        self.assertEqual(
+            class_to._ClassObject__relationships[0].get_target_class(), class_from
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parse_class_pattern/test_strategy.py
+++ b/tests/test_parse_class_pattern/test_strategy.py
@@ -81,7 +81,7 @@ class TestRelationshipStrategyBidirectional(unittest.TestCase):
 
     def test_one_to_many_bidirectional(self):
         strategy = ManyToOneStrategy()
-        edge = {"startLabel": "*", "endLabel": "1"}
+        edge = {"startLabel": "1", "endLabel": "*"}
         class_from = ClassObject()
         class_to = ClassObject()
 


### PR DESCRIPTION
Part of MOT-99
This pull request introduces a significant enhancement to the codebase by adding support for generating Spring Boot-style model templates and enabling bidirectional relationship parsing. Key changes include new methods for Spring Boot template generation, updates to relationship strategies, and extensive test coverage for these features.

### Spring Boot Model Template Generation:
* Added `to_models_springboot_context` in `ClassObject` to generate Spring Boot-specific context for classes, including fields and relationships. (`app/models/diagram.py`, [app/models/diagram.pyR71-R101](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680R71-R101))
* Introduced `to_springboot_models_template` methods in relationship and field classes to map relationships and fields to Spring Boot annotations and types. (`app/models/diagram.py`, [[1]](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680R209-R216) [[2]](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680R242-R252) [[3]](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680R271-R281); `app/models/properties.py`, [[4]](diffhunk://#diff-ac065d402cf0522ea562e6ec590ff895dcfab0d925f65a24f2d2bbb7a4c307b6R129-R136)
* Added `SPRING_TYPE_MAPPING` in `FieldObject` to map field types to Spring Boot-compatible types. (`app/models/properties.py`, [app/models/properties.pyR73-R91](diffhunk://#diff-ac065d402cf0522ea562e6ec590ff895dcfab0d925f65a24f2d2bbb7a4c307b6R73-R91))
* Implemented `print_springboot_style` in `ModelsElements` to render Spring Boot model templates using Jinja. (`app/models/elements.py`, [app/models/elements.pyR109-R136](diffhunk://#diff-8367d83e0338e7cef59037b6e2f43952e60d9fe417368d7e350dfb06fa21f640R109-R136))
* Added a new Jinja template `springboot/model.j2` for Spring Boot model generation. (`app/templates/springboot/model.j2`, [app/templates/springboot/model.j2R1-R40](diffhunk://#diff-6b31ef6d9dc239adcf11b4e80bc16bfb4f5e00d6f68a5738c142974efb6fbba6R1-R40))

### Bidirectional Relationship Parsing:
* Updated `create_relationship` methods in relationship strategies (`OneToOneStrategy`, `ManyToOneStrategy`, `ManyToManyStrategy`) to support bidirectional relationships. (`app/parse_class_pattern/parse_relationship_strategy.py`, [[1]](diffhunk://#diff-b5b1ba6ae42514a43bcdc43ecb1dcfaec50c9e56c7e47ac22e7cc3789545114bL11-R15) [[2]](diffhunk://#diff-b5b1ba6ae42514a43bcdc43ecb1dcfaec50c9e56c7e47ac22e7cc3789545114bL20-R51) [[3]](diffhunk://#diff-b5b1ba6ae42514a43bcdc43ecb1dcfaec50c9e56c7e47ac22e7cc3789545114bR66-R108)
* Modified `parse_relationships` in `ParseJsonToObjectClass` to accept a `bidirectional` flag. (`app/parse_json_to_object_class.py`, [[1]](diffhunk://#diff-c0001b02d7e400a8e68c0efcbb1e4413600f9a1616432b24069f3aece1ecfe05L58-R60) [[2]](diffhunk://#diff-c0001b02d7e400a8e68c0efcbb1e4413600f9a1616432b24069f3aece1ecfe05L78-R82)

### Test Coverage:
* Added unit tests for Spring Boot template generation in `test_model_springboot.py`, covering positive, negative, and edge cases for both classes and fields. (`tests/test_model_springboot.py`, [tests/test_model_springboot.pyR1-R139](diffhunk://#diff-ba334c59511be734240099e7ad13d466f2f7807b19bf2c37c96799f6636cb9ddR1-R139))
* Introduced tests for bidirectional relationship parsing in `test_strategy.py`. (`tests/test_parse_class_pattern/test_strategy.py`, [tests/test_parse_class_pattern/test_strategy.pyR51-R112](diffhunk://#diff-45d4f19e23561106ecda9792f3b63a9fc7d105120d85c136fe0bc245000b6677R51-R112))

These changes enhance the system's flexibility by supporting a new framework (Spring Boot) and improving relationship modeling capabilities.