### PR TITLE
Pbi 8 6 determine and add spring dependencies

### DIFF
--- a/app/models/elements.py
+++ b/app/models/elements.py
@@ -272,9 +272,10 @@ class DependencyElements(FileElements):
     This class is only for writing script for dependency in springboot framework
     """
 
-    def print_django_style(  # change to print_springboot_style
-        self, project_name: str
-    ) -> str:
+    def print_django_style(self) -> str:
+        return super().print_django_style()
+
+    def print_springboot_style(self, project_name: str) -> str:
         context = {
             "project_name": project_name,
             "java": "21",

--- a/app/models/elements.py
+++ b/app/models/elements.py
@@ -265,3 +265,43 @@ class RunBatScriptElements(FileElements):
         with open("app/templates/scripts/run.bat.txt", "r", encoding="utf-8") as file:
             bat = file.read()
         return bat
+
+
+class DependencyElements(FileElements):
+    """
+    This class is only for writing script for dependency in springboot framework
+    """
+
+    def print_django_style(  # change to print_springboot_style
+        self, project_name: str
+    ) -> str:
+        context = {
+            "project_name": project_name,
+            "java": "21",
+            "spring_boot": "3.4",
+            "dependencies": [
+                "org.springframework.boot:spring-boot-starter-thymeleaf",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-data-jpa",
+                "org.springframework.boot:spring-boot-starter-validation",
+                "org.springframework.boot:spring-boot-starter",
+                "com.zaxxer:HikariCP",
+                "org.xerial:sqlite-jdbc:3.41.2.2",
+                "jakarta.persistence:jakarta.persistence-api:3.1.0",
+                "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0",
+                "org.hibernate:hibernate-core:5.6.9.Final",
+                "org.xerial:sqlite-jdbc:3.41.2.2",
+                "org.hibernate.orm:hibernate-community-dialects",
+            ],
+            "repositories": [
+                "mavenCentral()",
+                "maven { url 'https://repo.spring.io/milestone' }",
+                "maven { url 'https://repo.spring.io/release' }",
+            ],
+        }
+        try:
+            if project_name == "":
+                raise ValueError("Project name cannot be empty!")
+            return render_template("springboot/build.gradle.kts.j2", context=context)
+        except Exception as e:
+            raise ValueError(f"Error rendering template: {e}")

--- a/app/templates/springboot/build.gradle.kts.j2
+++ b/app/templates/springboot/build.gradle.kts.j2
@@ -1,0 +1,46 @@
+plugins {
+	java
+	id("org.springframework.boot") version "{{ spring_boot_version }}"
+	id("io.spring.dependency-management") version "1.1.7"
+}
+
+group = "{{ project_name }}"
+version = "0.0.1-SNAPSHOT"
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of({{ java_version }})
+	}
+}
+
+configurations {
+	compileOnly {
+		extendsFrom(configurations.annotationProcessor.get())
+	}
+}
+
+repositories {
+	{%- for repo in repositories %}
+    {{ repo }}
+    {% endfor -%}
+}
+
+dependencies {
+	{%- for dependency in dependencies %}
+    implementation({{ dependency }})
+    {% endfor -%}
+
+	// Lombok
+	compileOnly("org.projectlombok:lombok:1.18.24")
+
+	developmentOnly("org.springframework.boot:spring-boot-devtools")
+	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+	annotationProcessor("org.projectlombok:lombok")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+
+tasks.withType<Test> {
+	useJUnitPlatform()
+}

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from app.models.diagram import ClassObject
 from app.models.elements import (
+    DependencyElements,
     ModelsElements,
     RequirementsElements,
     UrlsElement,
@@ -245,6 +246,42 @@ class TestRequirementsElements(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(Path("./app/requirements.txt").is_file())
         if Path("./app/requirements.txt").is_file():
             os.remove("./app/requirements.txt")
+
+
+class TestDependencyElements(unittest.TestCase):
+    def setUp(self):
+        self.dependency_elements = DependencyElements("build.gradle.kts")
+
+    def test_print_django_style_positive_case(self):
+        """Test: Positive case where valid project name is provided."""
+        project_name = "MySpringBootApp"
+        result = self.dependency_elements.print_django_style(project_name)
+        self.assertIn("MySpringBootApp", result)
+        self.assertIn("org.springframework.boot:spring-boot-starter-web", result)
+        self.assertIn("mavenCentral()", result)
+
+    def test_print_django_style_negative_case_empty_project_name(self):
+        """Test: Negative case where an empty project name is provided."""
+        project_name = ""
+        with self.assertRaises(Exception) as e:
+            self.dependency_elements.print_django_style(project_name)
+        self.assertEqual(
+            str(e.exception), "Error rendering template: Project name cannot be empty!"
+        )
+
+    def test_print_django_style_edge_case_long_project_name(self):
+        """Test: Edge case where a very long project name is provided."""
+        project_name = "A" * 1000  # Very long project name
+        result = self.dependency_elements.print_django_style(project_name)
+        self.assertIn("A" * 1000, result)
+        self.assertIn("org.springframework.boot:spring-boot-starter-web", result)
+
+    def test_print_django_style_edge_case_special_characters_in_project_name(self):
+        """Test: Edge case where project name contains special characters."""
+        project_name = "My@Spring#Boot$App!"
+        result = self.dependency_elements.print_django_style(project_name)
+        self.assertIn("My@Spring#Boot$App!", result)
+        self.assertIn("org.springframework.boot:spring-boot-starter-web", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -252,34 +252,34 @@ class TestDependencyElements(unittest.TestCase):
     def setUp(self):
         self.dependency_elements = DependencyElements("build.gradle.kts")
 
-    def test_print_django_style_positive_case(self):
+    def test_print_springboot_style_positive_case(self):
         """Test: Positive case where valid project name is provided."""
         project_name = "MySpringBootApp"
-        result = self.dependency_elements.print_django_style(project_name)
+        result = self.dependency_elements.print_springboot_style(project_name)
         self.assertIn("MySpringBootApp", result)
         self.assertIn("org.springframework.boot:spring-boot-starter-web", result)
         self.assertIn("mavenCentral()", result)
 
-    def test_print_django_style_negative_case_empty_project_name(self):
+    def test_print_springboot_style_negative_case_empty_project_name(self):
         """Test: Negative case where an empty project name is provided."""
         project_name = ""
         with self.assertRaises(Exception) as e:
-            self.dependency_elements.print_django_style(project_name)
+            self.dependency_elements.print_springboot_style(project_name)
         self.assertEqual(
             str(e.exception), "Error rendering template: Project name cannot be empty!"
         )
 
-    def test_print_django_style_edge_case_long_project_name(self):
+    def test_print_springboot_style_edge_case_long_project_name(self):
         """Test: Edge case where a very long project name is provided."""
         project_name = "A" * 1000  # Very long project name
-        result = self.dependency_elements.print_django_style(project_name)
+        result = self.dependency_elements.print_springboot_style(project_name)
         self.assertIn("A" * 1000, result)
         self.assertIn("org.springframework.boot:spring-boot-starter-web", result)
 
-    def test_print_django_style_edge_case_special_characters_in_project_name(self):
+    def test_print_springboot_style_edge_case_special_characters_in_project_name(self):
         """Test: Edge case where project name contains special characters."""
         project_name = "My@Spring#Boot$App!"
-        result = self.dependency_elements.print_django_style(project_name)
+        result = self.dependency_elements.print_springboot_style(project_name)
         self.assertIn("My@Spring#Boot$App!", result)
         self.assertIn("org.springframework.boot:spring-boot-starter-web", result)
 


### PR DESCRIPTION
Part of MOT-113
This pull request introduces a new `DependencyElements` class for generating Spring Boot project configuration files and adds corresponding unit tests. The most important changes include implementing the `DependencyElements` class, creating a Jinja2 template for `build.gradle.kts`, and adding test cases to validate the new functionality.

### New Feature: Spring Boot Dependency Management

* **`DependencyElements` class added**: A new class `DependencyElements` was created in `app/models/elements.py` to generate Spring Boot project configuration files using a Jinja2 template. It includes a method `print_django_style` (which should be renamed to `print_springboot_style`) for rendering the template with project-specific data.

* **Jinja2 template for `build.gradle.kts`**: Added a new template file `app/templates/springboot/build.gradle.kts.j2` to define the structure of the `build.gradle.kts` file. It dynamically incorporates dependencies, repositories, and project-specific settings.

### Testing Enhancements

* **Unit tests for `DependencyElements`**: Added a new test class `TestDependencyElements` in `tests/test_elements.py` to validate the functionality of the `DependencyElements` class. It includes positive, negative, and edge case tests for the `print_django_style` method.

* **Import update**: Updated imports in `tests/test_elements.py` to include the new `DependencyElements` class.