### PR TITLE
PBI 8: 3 - feat: function to initialize spring boot project from self hosted spring initializr

### DIFF
--- a/.github/scripts/update_version.sh
+++ b/.github/scripts/update_version.sh
@@ -20,7 +20,7 @@ if [[ "$BRANCH" == "main" ]]; then
 elif [[ "$BRANCH" == "staging" ]]; then
   MINOR=$((MINOR + 1))
   PATCH=0
-elif [[ "$BRANCH" == "dev" ]]; then
+elif [[ "$BRANCH" =~ ^BUG-FIX- ]] || [[ "$BRANCH" == "dev" ]]; then
   PATCH=$((PATCH + 1))
 else
   echo "Branch not recognized: $BRANCH. No version update performed."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,34 +4,57 @@ on:
   workflow_run:
     workflows: [Update Version]
     types: [completed]
-    branches: [main, staging, dev]
+    branches:
+      - main
+      - staging
+      - dev
+      - 'BUG-FIX-*'
 
 jobs:
-  build-and-push:
+  determine-branch:
     runs-on: ubuntu-latest
 
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      stop: ${{ steps.result.outputs.stop }}
+      branch: ${{ steps.result.outputs.branch }}
     steps:
-      - name: Determine branch to checkout
+      - name: Download merge info
+        uses: actions/download-artifact@v4
+        with:
+          name: merge-metadata
+          path: ./merge-data
+
+      - name: Determine branch to checkout or stop
+        id: result
         run: |
-          if [[ "${{ github.event.workflow_run.head_branch }}" == "dev" ]]; then
-            echo "BRANCH=staging" >> $GITHUB_ENV
-          elif [[ "${{ github.event.workflow_run.head_branch }}" == "staging" ]]; then
-            echo "BRANCH=main" >> $GITHUB_ENV
-          else
-            echo "Invalid branch to build from"
+          if [ ! -f "./merge-data/merge_info.env" ]; then
+            echo "Error: merge_info.env not found!"
             exit 1
           fi
 
+          source ./merge-data/merge_info.env
+          if [[ "$BRANCH" == "dev" ]]; then
+            echo "stop=true" >> $GITHUB_OUTPUT
+          else
+            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+            echo "stop=false" >> $GITHUB_OUTPUT
+          fi
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: determine-branch
+    if: ${{ !needs.determine-branch.outputs.stop }}
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
+          ref: ${{ needs.determine-branch.outputs.branch }}
           fetch-tags: true
 
       - name: Get Git tag
         run: |
-          GIT_TAG=$(git describe --tags --exact-match ${{ env.BRANCH }} || echo "")
+          GIT_TAG=$(git describe --tags --exact-match ${{ needs.determine-branch.outputs.branch }} || echo "")
           if [ -z "$GIT_TAG" ]; then
             echo "No tag found for this commit."
             exit 1

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -8,6 +8,7 @@ on:
       - main
       - staging
       - dev
+      - 'BUG-FIX-*'
 
 jobs:
   update-version:
@@ -63,6 +64,15 @@ jobs:
             echo "Pushing version update to $BRANCH branch..."
             git push origin HEAD:$BRANCH
           done
+
+      - name: Save merged branch info
+        run: echo "BRANCH=${{ github.base_ref }}" >> merge_info.env
+
+      - name: Upload merge info
+        uses: actions/upload-artifact@v4
+        with:
+          name: merge-metadata
+          path: merge_info.env
 
       - name: Create Git Tag
         uses: anothrNick/github-tag-action@1.71.0

--- a/app/config.py
+++ b/app/config.py
@@ -8,3 +8,9 @@ APP_CONFIG = {
     "version": VERSION,
     "title": "MoTxT Convert",
 }
+SPRING_SERVICE_URL = os.getenv("SPRING_SERVICE_URL", "http://localhost:8080")
+SPRING_DEPENDENCIES = (
+    "lombok,devtools,configuration-processor,web,data-jpa,validation,"
+    "springdoc-starter-webmvc-ui,hibernate-core,hibernate-community-dialects,"
+    "hikaricp,sqlite,jakarta-persistence-api"
+)

--- a/app/main.py
+++ b/app/main.py
@@ -524,13 +524,15 @@ async def initialize_springboot_zip(project_name: str, group_id: str) -> str:
                 detail="Unknown error occured. Initializr service might be down.",
             )
 
-        if resp.headers["content-type"] != "application/zip":
+        content_type = resp.headers["content-type"]
+        if content_type != "application/zip":
             raise HTTPException(
                 status_code=500,
-                detail=f"Unexpected content type from server: {resp.headers['content-type']}.",
+                detail=f"Unexpected content type from server: {content_type}.",
             )
 
-        if len(resp.content) == 0:
+        content = resp.content
+        if len(content) == 0:
             raise HTTPException(
                 status_code=500, detail="Failed to create zip, please try again later."
             )
@@ -548,5 +550,5 @@ async def initialize_springboot_zip(project_name: str, group_id: str) -> str:
         )
 
     async with anyio.NamedTemporaryFile(suffix=".zip", delete=False) as f:
-        await f.write(resp.content)
+        await f.write(content)
         return f.name

--- a/app/main.py
+++ b/app/main.py
@@ -7,13 +7,14 @@ from contextlib import asynccontextmanager
 from io import StringIO
 
 import anyio
+import httpx
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import FileResponse
 from prometheus_client import Counter, Histogram
 from prometheus_fastapi_instrumentator import Instrumentator
 from starlette.background import BackgroundTasks
 
-from app.config import APP_CONFIG
+from app.config import APP_CONFIG, SPRING_DEPENDENCIES, SPRING_SERVICE_URL
 from app.generate_frontend.create.create_page_views import generate_create_page_views
 from app.generate_frontend.create.generate_create_page_django import (
     generate_forms_create_page_django,
@@ -501,3 +502,51 @@ def fetch_data(filenames: list[str], contents: list[list[str]]) -> dict[str]:
         "views": response_content_views.getvalue(),
         "model_element": writer_models,
     }
+
+
+async def initialize_springboot_zip(project_name: str, group_id: str) -> str:
+    params = {
+        "javaVersion": "21",
+        "artifactId": project_name.lower(),
+        "groupId": group_id,
+        "name": project_name,
+        "packaging": "jar",
+        "type": "gradle-project-kotlin",
+        "dependencies": SPRING_DEPENDENCIES,
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(SPRING_SERVICE_URL, params=params)
+
+        if resp.status_code != 200:
+            raise HTTPException(
+                status_code=500,
+                detail="Unknown error occured. Initializr service might be down.",
+            )
+
+        if resp.headers["content-type"] != "application/zip":
+            raise HTTPException(
+                status_code=500,
+                detail=f"Unexpected content type from server: {resp.headers['content-type']}.",
+            )
+
+        if len(resp.content) == 0:
+            raise HTTPException(
+                status_code=500, detail="Failed to create zip, please try again later."
+            )
+
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=503,
+            detail="Initializr service timed out. Please try again later.",
+        )
+
+    except httpx.NetworkError:
+        raise HTTPException(
+            status_code=503,
+            detail="Cannot connect to Initializr service. Service might be down.",
+        )
+
+    async with anyio.NamedTemporaryFile(suffix=".zip", delete=False) as f:
+        await f.write(resp.content)
+        return f.name

--- a/tests/test_initialize_spring_zip.py
+++ b/tests/test_initialize_spring_zip.py
@@ -1,0 +1,120 @@
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import httpx
+from fastapi import HTTPException
+
+from app.main import initialize_springboot_zip
+
+
+class TestInitializeSpringZip(unittest.IsolatedAsyncioTestCase):
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_successful_download_with_zip_content(self, mock_get: AsyncMock):
+        """Test successful download with zip content returns tempfile path"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/zip"}
+        mock_response.content = b"PK\x03\x04"
+
+        mock_get.return_value = mock_response
+        temp_file_path = await initialize_springboot_zip()
+
+        mock_get.assert_called_once_with("http://localhost:8080")
+        self.assertTrue(temp_file_path.endswith(".zip"))
+        # Verify file exists and has content
+        async with await anyio.open_file(temp_file_path, "rb") as f:
+            self.assertEqual(await f.read(), b"PK\x03\x04")
+
+        os.remove(temp_file_path)
+
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_non_200_status_raises_exception(self, mock_get: AsyncMock):
+        """Test non-200 status code raises HTTPException"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 500
+
+        mock_get.return_value = mock_response
+        with self.assertRaises(HTTPException) as ctx:
+            await initialize_springboot_zip()
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Unknown error occured. Initializr service might be down.",
+        )
+
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_non_zip_content_raises_exception(self, mock_get: AsyncMock):
+        """Test non-zip content type raises HTTPException"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(HTTPException) as ctx:
+            await initialize_springboot_zip()
+
+        self.assertEqual(
+            str(ctx.exception), "Unexpected content type from server: text/html."
+        )
+
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_timeout_raises_exception(self, mock_get: AsyncMock):
+        """Test timeout raises HTTPException"""
+        mock_get.side_effect = httpx.TimeoutException("Timeout")
+        with self.assertRaises(HTTPException) as ctx:
+            await initialize_springboot_zip()
+
+        self.assertEqual(
+            str(ctx.exception), "Initializr service timed out. Please try again later."
+        )
+
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_connection_error_raises_exception(self, mock_get: AsyncMock):
+        """Test connection error raises HTTPException"""
+        mock_get.side_effect = httpx.ConnectError("Connection error")
+        with self.assertRaises(HTTPException) as ctx:
+            await initialize_springboot_zip()
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Cannot connect to Initializr service. Service might be down.",
+        )
+
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_empty_response_raises_exception(self, mock_get: AsyncMock):
+        """Test empty response raises HTTPException"""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/zip"}
+        mock_response.content = b""
+
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(HTTPException) as ctx:
+            await initialize_springboot_zip()
+
+        self.assertEqual(
+            str(ctx.exception), "Failed to create zip, please try again later."
+        )
+
+    @patch("app.main.initialize_springboot_zip.httpx.AsyncClient.get")
+    async def test_large_zip_file_handled_properly(self, mock_get: AsyncMock):
+        """Test large zip file is handled correctly"""
+        large_content = b"0" * (1024 * 1024)  # 1MB of data
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/zip"}
+        mock_response.content = large_content
+
+        mock_get.return_value = mock_response
+
+        temp_file_path = await initialize_springboot_zip()
+
+        async with await anyio.open_file(temp_file_path, "rb") as f:
+            self.assertEqual(len(await f.read()), len(large_content))
+
+        os.remove(temp_file_path)


### PR DESCRIPTION
Part of MOT-108
- Added function to initiate zip file creation of the spring boot project through spring initializr. This function will return the temp file path. This function assumes that the `project_name` and `group_id` is already validated from the caller.
- Changed the `update_version` workflow so now if there are pull request from any branch with the pattern `BUG-FIX-*`, we can make the target branch staging or main to quickly deliver it to the deployed build, rather than having to go through dev.