### PR TITLE
PBI 8: 8 - Make Spring Project Downloadable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/app/main.py
+++ b/app/main.py
@@ -114,11 +114,9 @@ async def convert(
         if request.project_type == "django":
             tmp_zip_path = await convert_django(project_name, filenames, contents)
         else:
-            print("convert spring")
             tmp_zip_path = await convert_spring(
                 project_name, request.group_id, filenames, contents
             )
-            print(f"{tmp_zip_path = }")
         background_tasks.add_task(remove_file, tmp_zip_path)
 
         return FileResponse(
@@ -134,6 +132,19 @@ async def convert(
             "Error occurred at parsing: " + ex_str.replace("\n", " "), exc_info=True
         )
         raise HTTPException(status_code=422, detail=ex_str)
+
+    except HTTPException:
+        raise
+
+    except Exception as ex:
+        ex_str = str(ex)
+        logger.warning(
+            "Unknown error occured: " + ex_str.replace("\n", " "), exc_info=True
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unknown error occured: {ex_str}\nPlease try again later",
+        )
 
 
 async def convert_django(
@@ -212,17 +223,22 @@ async def convert_spring(
     project_name: str, group_id: str, filenames: list[str], contents: list[list[str]]
 ) -> str:
     if not is_valid_java_group_id(group_id):
-        raise HTTPException(status_code=400, detail=f"Invalid group id: {group_id}")
+        msg = f"Invalid group id: {group_id}"
+        logger.warning(msg)
+        raise HTTPException(status_code=400, detail=msg)
 
     # TODO: All other PBI 8 to integrate here
     # This line is for quick integration when PBI 8: 3 gets merged
     # tmp_zip_path = await initialize_springboot_zip(project_name, group_id)
 
-    tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
-    tmp_zip_path = tmp_zip.name
+    # Below are not covered yet because there's no real logic yet
+    tmp_zip = tempfile.NamedTemporaryFile(
+        suffix=".zip", delete=False
+    )  # pragma: no cover
+    tmp_zip_path = tmp_zip.name  # pragma: no cover
 
-    tmp_zip.close()
-    return tmp_zip_path
+    tmp_zip.close()  # pragma: no cover
+    return tmp_zip_path  # pragma: no cover
 
 
 def check_duplicate(

--- a/app/model.py
+++ b/app/model.py
@@ -1,3 +1,5 @@
+from typing import Literal, Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -5,6 +7,8 @@ class ConvertRequest(BaseModel):
     filename: list[str] = Field(min_length=1)
     content: list[list[str]] = Field(min_length=1)
     project_name: str = Field(min_length=1)
+    project_type: Literal["django", "spring"] = Field(min_length=1, default="django")
+    group_id: Optional[str] = Field(min_length=1, default="com.example")
 
 
 class DownloadRequest(BaseModel):

--- a/app/utils.py
+++ b/app/utils.py
@@ -9,6 +9,7 @@ from jinja2 import Environment, PackageLoader, TemplateNotFound
 
 env = Environment(loader=PackageLoader("app"))  # nosec B701 - not used for rendering HTML to the user
 logger = logging.getLogger("uvicorn.error")
+JAVA_GROUP_ID_REGEX = re.compile(r"^([a-zA-Z_]{1}\w*(\.[a-zA-Z_]{1}\w*)*)?$")
 
 
 def remove_file(path: str) -> None:
@@ -17,6 +18,10 @@ def remove_file(path: str) -> None:
 
 def is_valid_python_identifier(identifier: str) -> bool:
     return identifier.isidentifier() and not iskeyword(identifier)
+
+
+def is_valid_java_group_id(group_id: str) -> bool:
+    return JAVA_GROUP_ID_REGEX.match(group_id) is not None
 
 
 def render_template(

--- a/app/utils.py
+++ b/app/utils.py
@@ -79,9 +79,6 @@ def is_valid_python_identifier(identifier: str) -> bool:
 
 
 def is_valid_java_group_id(group_id: str) -> bool:
-    if not group_id:
-        return False
-
     for component in group_id.split("."):
         if not component:
             return False

--- a/app/utils.py
+++ b/app/utils.py
@@ -9,7 +9,65 @@ from jinja2 import Environment, PackageLoader, TemplateNotFound
 
 env = Environment(loader=PackageLoader("app"))  # nosec B701 - not used for rendering HTML to the user
 logger = logging.getLogger("uvicorn.error")
-JAVA_GROUP_ID_REGEX = re.compile(r"^([a-zA-Z_]{1}\w*(\.[a-zA-Z_]{1}\w*)*)?$")
+JAVA_IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z_]\w*$")
+JAVA_KEYWORDS = {
+    "abstract",
+    "assert",
+    "boolean",
+    "break",
+    "byte",
+    "case",
+    "catch",
+    "char",
+    "class",
+    "const",
+    "continue",
+    "default",
+    "do",
+    "double",
+    "else",
+    "enum",
+    "extends",
+    "final",
+    "finally",
+    "float",
+    "for",
+    "goto",
+    "if",
+    "implements",
+    "import",
+    "instanceof",
+    "int",
+    "interface",
+    "long",
+    "native",
+    "new",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "return",
+    "short",
+    "static",
+    "strictfp",
+    "super",
+    "switch",
+    "synchronized",
+    "this",
+    "throw",
+    "throws",
+    "transient",
+    "try",
+    "void",
+    "volatile",
+    "while",
+    "var",
+    "record",
+    "yield",
+    "sealed",
+    "permits",
+    "non-sealed",
+}
 
 
 def remove_file(path: str) -> None:
@@ -21,7 +79,20 @@ def is_valid_python_identifier(identifier: str) -> bool:
 
 
 def is_valid_java_group_id(group_id: str) -> bool:
-    return JAVA_GROUP_ID_REGEX.match(group_id) is not None
+    if not group_id:
+        return False
+
+    for component in group_id.split("."):
+        if not component:
+            return False
+
+        if component in JAVA_KEYWORDS:
+            return False
+
+        if not JAVA_IDENTIFIER_PATTERN.match(component):
+            return False
+
+    return True
 
 
 def render_template(

--- a/tests/test_download_spring_proj.py
+++ b/tests/test_download_spring_proj.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.utils import is_valid_java_group_id
 
 client = TestClient(app)
 
@@ -68,8 +69,12 @@ class TestDownloadSpringProject(unittest.IsolatedAsyncioTestCase):
         When group_id is not following java package naming conventions
         it should return 400 and a message telling it is an invalid group_id
         """
-        for group_id in ["123.abcd", ":a.ha", ".abcd", "hjk.", "ab;cd;ef"]:
+        for group_id in ["123.abcd", ":a.ha", ".abcd", "hjk.", "int.abc"]:
             self.json["group_id"] = group_id
             resp = client.post("/convert", json=self.json)
             self.assertEqual(resp.status_code, 400)
             self.assertEqual(resp.json()["detail"], f"Invalid group id: {group_id}")
+
+    async def test_valid_group_id(self):
+        for group_id in ["com.example", "abc.def", "A_asdf.K_", "_asf123._32"]:
+            self.assertTrue(is_valid_java_group_id(group_id))

--- a/tests/test_download_spring_proj.py
+++ b/tests/test_download_spring_proj.py
@@ -1,0 +1,75 @@
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+class TestDownloadSpringProject(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.json = {
+            "filename": ["test_spring"],
+            "content": [["test content"]],
+            "project_name": "spring",
+            "group_id": "com.motxt",
+            "project_type": "spring",
+        }
+
+    @patch("app.main.convert_spring")
+    async def test_correct_proj_type(self, mock_spring: AsyncMock):
+        """Should be modified after PBI 8-3 gets merged"""
+        tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+        with zipfile.ZipFile(tmp_zip.name, "w") as f:
+            f.writestr("build.gradle.kts", "testing")
+            f.mkdir("src")
+            f.mkdir("src/main")
+            f.mkdir("src/main/java")
+            f.mkdir("src/main/java/com")
+            f.mkdir("src/main/java/com/motxt")
+            f.mkdir("src/main/java/com/motxt/spring")
+        tmp_zip.close()
+        mock_spring.return_value = tmp_zip.name
+        resp = client.post("/convert", json=self.json)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers["content-type"], "application/zip")
+        self.assertIn(b"PK\x03\x04", resp.content)
+        self.assertIn(b"build.gradle.kts", resp.content)
+        self.assertIn(b"motxt", resp.content)
+
+    @patch("app.main.convert_spring")
+    async def test_empty_group_id(self, mock_spring: AsyncMock):
+        """
+        When group_id is empty, will use com.example
+        Should be modified after PBI 8-3 gets merged
+        """
+        tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+        with zipfile.ZipFile(tmp_zip.name, "w") as f:
+            f.mkdir("src")
+            f.mkdir("src/main")
+            f.mkdir("src/main/java")
+            f.mkdir("src/main/java/com")
+            f.mkdir("src/main/java/com/example")
+            f.mkdir("src/main/java/com/example/spring")
+        tmp_zip.close()
+        mock_spring.return_value = tmp_zip.name
+        self.json.pop("group_id")
+        resp = client.post("/convert", json=self.json)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"com", resp.content)
+        self.assertIn(b"example", resp.content)
+
+    async def test_invalid_group_id(self):
+        """
+        When group_id is not following java package naming conventions
+        it should return 400 and a message telling it is an invalid group_id
+        """
+        for group_id in ["123.abcd", ":a.ha", ".abcd", "hjk.", "ab;cd;ef"]:
+            self.json["group_id"] = group_id
+            resp = client.post("/convert", json=self.json)
+            self.assertEqual(resp.status_code, 400)
+            self.assertEqual(resp.json()["detail"], f"Invalid group id: {group_id}")


### PR DESCRIPTION
Part of MOT-123
- Modified the `convert` function so that it now can accept either `django` (default) or `spring` project types. When the project type is `spring`, if the `group_id` is not sent by the user, then it will be defaulted to `com.example` for now.
- Added logging to unexpected exceptions

The function I added in this PR does not do much currently, but when we are going to integrate, the integrators can just put it in the provided function rather than having to modify a lot more. Currently the function just checks for the `group_id` if it is a valid Java package name or not. If it is then it just create some temporary file, which if PBI 8-3 is merged, it should be replaced by that function instead.