### PR TITLE
Pbi 8 7 integrate generated spring project with swagger from pbi 9

### DIFF
--- a/app/generate_swagger/generate_swagger.py
+++ b/app/generate_swagger/generate_swagger.py
@@ -3,8 +3,8 @@ from app.utils import render_template
 
 
 # Call this to generate SwaggerConfig.java
-def generate_swagger_config(project_name: str) -> str:
-    context = {"project_name": project_name}
+def generate_swagger_config(trailing_name: str, project_name: str) -> str:
+    context = {"trailng_name": trailing_name, "project_name": project_name}
     return render_template("SwaggerConfig.java.j2", context)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,13 @@ from app.generate_frontend.read.generate_read_page_django import (
     generate_html_read_pages_django,
 )
 from app.generate_frontend.read.read_page_views import generate_read_page_views
+from app.generate_runner.generate_runner import (
+    generate_springboot_linux_runner,
+    generate_springboot_window_runner,
+)
+from app.generate_swagger.generate_swagger import (
+    generate_swagger_config,
+)
 from app.model import ConvertRequest, DownloadRequest
 from app.models.elements import (
     ClassObject,
@@ -233,6 +240,21 @@ async def convert_spring(
         suffix=".zip", delete=False
     )  # pragma: no cover
     tmp_zip_path = tmp_zip.name  # pragma: no cover
+
+    with zipfile.ZipFile(tmp_zip_path, "w") as zipf:
+        # put swagger config to zip
+        swagger_config_content = generate_swagger_config(group_id, project_name)
+        zipf.writestr(
+            f"{group_id.replace('.', '/')}/config/SwaggerConfig.java",
+            swagger_config_content,
+            compress_type=zipfile.ZIP_DEFLATED,
+        )
+
+        # put runner to zip
+        windows_runner = generate_springboot_window_runner()
+        linux_runner = generate_springboot_linux_runner()
+        zipf.writestr("run.bat", windows_runner, compress_type=zipfile.ZIP_DEFLATED)
+        zipf.writestr("run.sh", linux_runner, compress_type=zipfile.ZIP_DEFLATED)
 
     tmp_zip.close()  # pragma: no cover
     return tmp_zip_path  # pragma: no cover

--- a/app/main.py
+++ b/app/main.py
@@ -35,16 +35,16 @@ from app.generate_frontend.read.generate_read_page_django import (
     generate_html_read_pages_django,
 )
 from app.generate_frontend.read.read_page_views import generate_read_page_views
+from app.generate_repository.generate_repository import generate_repository_java
 from app.generate_runner.generate_runner import (
     generate_springboot_linux_runner,
     generate_springboot_window_runner,
 )
-from app.generate_swagger.generate_swagger import (
-    generate_swagger_config,
-)
-from app.generate_repository.generate_repository import generate_repository_java
 from app.generate_service_springboot.generate_service_springboot import (
     generate_service_java,
+)
+from app.generate_swagger.generate_swagger import (
+    generate_swagger_config,
 )
 from app.model import ConvertRequest, DownloadRequest
 from app.models.elements import (
@@ -261,7 +261,6 @@ async def convert_spring(
         linux_runner = generate_springboot_linux_runner()
         zipf.writestr("run.bat", windows_runner, compress_type=zipfile.ZIP_DEFLATED)
         zipf.writestr("run.sh", linux_runner, compress_type=zipfile.ZIP_DEFLATED)
-
 
         writer_models = ModelsElements("models.py")
         dependency = DependencyElements("application.properties")

--- a/app/templates/SwaggerConfig.java.j2
+++ b/app/templates/SwaggerConfig.java.j2
@@ -1,4 +1,4 @@
-package com.example.burhanpedia.config;
+package {{trailng_name}}.{{project_name}}.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;

--- a/tests/test_download_spring_proj.py
+++ b/tests/test_download_spring_proj.py
@@ -27,12 +27,12 @@ class TestDownloadSpringProject(unittest.IsolatedAsyncioTestCase):
         tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
         with zipfile.ZipFile(tmp_zip.name, "w") as f:
             f.writestr("build.gradle.kts", "testing")
-            f.mkdir("src")
-            f.mkdir("src/main")
-            f.mkdir("src/main/java")
-            f.mkdir("src/main/java/com")
-            f.mkdir("src/main/java/com/motxt")
-            f.mkdir("src/main/java/com/motxt/spring")
+            f.writestr("src", "")
+            f.writestr("src/main", "")
+            f.writestr("src/main/java", "")
+            f.writestr("src/main/java/com", "")
+            f.writestr("src/main/java/com/motxt", "")
+            f.writestr("src/main/java/com/motxt/spring", "")
         tmp_zip.close()
         mock_spring.return_value = tmp_zip.name
         resp = client.post("/convert", json=self.json)
@@ -50,12 +50,12 @@ class TestDownloadSpringProject(unittest.IsolatedAsyncioTestCase):
         """
         tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
         with zipfile.ZipFile(tmp_zip.name, "w") as f:
-            f.mkdir("src")
-            f.mkdir("src/main")
-            f.mkdir("src/main/java")
-            f.mkdir("src/main/java/com")
-            f.mkdir("src/main/java/com/example")
-            f.mkdir("src/main/java/com/example/spring")
+            f.writestr("src", "")
+            f.writestr("src/main", "")
+            f.writestr("src/main/java", "")
+            f.writestr("src/main/java/com", "")
+            f.writestr("src/main/java/com/example", "")
+            f.writestr("src/main/java/com/example/spring", "")
         tmp_zip.close()
         mock_spring.return_value = tmp_zip.name
         self.json.pop("group_id")

--- a/tests/test_generate_swagger.py
+++ b/tests/test_generate_swagger.py
@@ -16,7 +16,7 @@ class TestGenerateSwagger(unittest.TestCase):
     def test_generate_swagger_config(self):
         with open(os.path.join(TEST_DIR, "test_swagger_config.txt")) as f:
             expected = f.read().strip()
-            res = generate_swagger_config("project")
+            res = generate_swagger_config("com.example", "project")
             self.assertEqual(res, expected)
 
     def test_get_swagger_controller_import(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import app, check_duplicate
+from app.main import app, check_duplicate, convert_spring
 from app.models.elements import ClassObject, ModelsElements
 from app.models.methods import ClassMethodObject
 
@@ -529,3 +529,20 @@ def test_raise_value_error_on_main():
         "Please make sure the file submitted is not corrupt"
     }
     app.dependency_overrides.clear()  # Reset overrides after test
+
+
+@pytest.mark.asyncio
+async def test_convert_spring():
+    content = [
+        [
+            '{"diagram":"ClassDiagram", "nodes":[{"methods":"classMethod()", "name":"Test", '
+            '"x":100, "y":100}], "edges":[]}'
+        ],
+    ]
+    response = await convert_spring(
+        "file1", "com.example", ["file.class.jet"], contents=content
+    )
+
+    assert isinstance(response, str)
+    assert os.path.isfile(response)
+    os.remove(response)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -533,16 +533,19 @@ def test_raise_value_error_on_main():
 
 @pytest.mark.asyncio
 async def test_convert_spring():
-    content = [
-        [
-            '{"diagram":"ClassDiagram", "nodes":[{"methods":"classMethod()", "name":"Test", '
-            '"x":100, "y":100}], "edges":[]}'
-        ],
-    ]
-    response = await convert_spring(
-        "file1", "com.example", ["file.class.jet"], contents=content
-    )
+    with patch("app.main.initialize_springboot_zip") as mock_zip:
+        mock_zip.return_value = "a.zip"
+        content = [
+            [
+                '{"diagram":"ClassDiagram", "nodes":[{"id":0,"methods":"+ '
+                'classMethod(): string", "name":"Test", '
+                '"x":100, "y":100}], "edges":[]}'
+            ],
+        ]
+        response = await convert_spring(
+            "file1", "com.example", ["file.class.jet"], contents=content
+        )
 
-    assert isinstance(response, str)
-    assert os.path.isfile(response)
-    os.remove(response)
+        assert isinstance(response, str)
+        assert os.path.isfile(response)
+        os.remove(response)

--- a/tests/testdata/test_swagger_config.txt
+++ b/tests/testdata/test_swagger_config.txt
@@ -1,4 +1,4 @@
-package com.example.burhanpedia.config;
+package com.example.project.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;


### PR DESCRIPTION
On this PR I've implemented writing swagger config (and also runner to alleviate some the @NtapSlur 's job) to the zip. I didn't write the decorator for swagger on the controller because as I checked @DaWanAnOnli 's commits, that has already been implemented on the controller's jinjia itself. Also if you are wandering why the history is so long, it's because I pulled from all the main branch (PBI7, 8, 9) which was a mistake unfortunately because in hindsight, I only needed like 2 files maximum.

Cheers! [🍺](https://emojipedia.org/beer-mug)