### PR TITLE
feat: Write log to file and view it on Grafana

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ CMD [ \
     "--host", "0.0.0.0", \
     "--port", "8000", \
     "--workers", "4", \
-    "--log-config", "logger_conf.json" \
+    "--log-config", "${LOG_CONFIG_PATH:-logger_conf.json}" \
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD [ \
+    "uvicorn", "app.main:app", \
+    "--host", "0.0.0.0", \
+    "--port", "8000", \
+    "--workers", "4", \
+    "--log-config", "logger_conf.json" \
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   motxt-convert:
     build: .
     container_name: motxt-convert
+    volumes:
+      - ./logs:/app/logs
     ports:
       - "8000:8000"
     networks:
@@ -38,6 +40,31 @@ services:
         reservations:
           cpus: "0.25"
           memory: 64M
+
+  loki-convert:
+    image: grafana/loki:latest
+    container_name: loki-convert
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki-config.yaml:/etc/loki/loki-config.yaml
+    command: -config.file=/etc/loki/loki-config.yaml
+
+  promtail-convert:
+    image: grafana/promtail:latest
+    container_name: promtail-convert
+    volumes:
+      - ./monitoring/promtail-config.yaml:/etc/promtail/promtail-config.yaml
+      - ./logs:/var/log/
+    command: -config.file=/etc/promtail/promtail-config.yaml
+
+  grafana-convert:
+    image: grafana/grafana:latest
+    container_name: grafana-convert
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./monitoring/grafana-config.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
 
 networks:
   monitoring:

--- a/logger_conf.json
+++ b/logger_conf.json
@@ -1,0 +1,51 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "fmt": "%(asctime)s %(levelprefix)s %(message)s",
+            "use_colors": null
+        },
+        "access": {
+            "()": "uvicorn.logging.AccessFormatter",
+            "fmt": "%(asctime)s %(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s"
+        }
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": "/app/logs/convert.log",
+            "maxBytes": 10485760,
+            "backupCount": 5,
+            "encoding": "utf8"
+        },
+        "access": {
+            "formatter": "access",
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": "/app/logs/convert_access.log",
+            "maxBytes": 10485760,
+            "backupCount": 5,
+            "encoding": "utf8"
+        }
+    },
+    "loggers": {
+        "uvicorn": {
+            "handlers": [
+                "default"
+            ],
+            "level": "INFO"
+        },
+        "uvicorn.error": {
+            "level": "INFO"
+        },
+        "uvicorn.access": {
+            "handlers": [
+                "access"
+            ],
+            "level": "INFO",
+            "propagate": false
+        }
+    }
+}

--- a/monitoring/grafana-config.yaml
+++ b/monitoring/grafana-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  url: http://prometheus:9090
+  access: proxy
+  editable: true
+  isDefault: true
+
+- name: Loki
+  type: loki
+  access: proxy
+  url: http://loki:3100

--- a/monitoring/loki-config.yaml
+++ b/monitoring/loki-config.yaml
@@ -1,0 +1,32 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+analytics:
+  reporting_enabled: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "motxt-convert"
+    static_configs:
+      - targets: ["motxt-convert:8000"]

--- a/monitoring/promtail-config.yaml
+++ b/monitoring/promtail-config.yaml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: varlogs
+      __path__: /var/log/*.log*


### PR DESCRIPTION
Part of MOT-112
- Added logger config so that when the image is run, all of the logs should be written to a file, which then will be saved in the Docker host's machine so that recreating the container doesn't delete it.
- Added Grafana, Loki, and Promtail to the local `docker-compose.yml` so that we can check if it is working as intended. All you need to do if you want to check is `docker compose up -d` and then check `http://localhost:3100/ready` and wait until it says ready. After that, you can create a `Dashboard` in Grafana and choosing Loki as the datasource. On the `query` part, choose the `job` label and `varlogs` like the image below. Now, just turn on `Table view` as shown by the second image.
![image](https://github.com/user-attachments/assets/a7cdb784-8fa0-439b-a140-8669ffc5a64b)
![image](https://github.com/user-attachments/assets/76c08bbc-6457-48ce-8d11-445281827b56)

