### PR TITLE
fix: duplicate application.properties and build.gradle.kts file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r requirements-tests.txt
 
       - name: Run Tests
-        run: python -m pytest
+        run: python -m pytest --ignore=tests/integration
 
   linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
           pip install -r requirements-tests.txt
 
       - name: Run Tests with Coverage
-        run: python -m pytest --cov=app --cov-report=xml
+        run: python -m pytest --ignore=tests/integration --cov=app --cov-report=xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v4

--- a/app/main.py
+++ b/app/main.py
@@ -49,7 +49,6 @@ from app.generate_swagger.generate_swagger import (
 from app.model import ConvertRequest, DownloadRequest, Style
 from app.models.elements import (
     ClassObject,
-    DependencyElements,
     ModelsElements,
     RequirementsElements,
     UrlsElement,
@@ -274,7 +273,6 @@ async def convert_spring(
         zipf.writestr("run.sh", linux_runner, compress_type=zipfile.ZIP_DEFLATED)
 
         writer_models = ModelsElements("models.py")
-        dependency = DependencyElements("application.properties")
 
         classes = []
         for file_name, content in zip(filenames, contents):
@@ -293,10 +291,6 @@ async def convert_spring(
                 raise ValueError("Given diagram is not Class Diagram")
 
         model_files = writer_models.print_springboot_style(project_name, group_id)
-        zipf.writestr(
-            "src/main/resources/application.properties",
-            dependency.print_application_properties(),
-        )
 
         # Specific line of code to generate HomeController for Swagger Redirection
         zipf.writestr(
@@ -332,18 +326,7 @@ async def convert_spring(
                 generate_repository_java(project_name, class_object, group_id),
             )
 
-        fix_build_gradle_kts(zipf)
-
     return tmp_zip_path
-
-
-def fix_build_gradle_kts(zipf: zipfile.ZipFile):
-    build_gradle_kts = zipf.open("build.gradle.kts").read().decode()
-    build_gradle_kts = build_gradle_kts.replace(
-        '"org.springdoc:springdoc-openapi-starter-webmvc-ui"',
-        '"org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0"',
-    )
-    zipf.writestr("build.gradle.kts", build_gradle_kts)
 
 
 def write_springboot_path(src_path: str, file: str, class_name: str) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -46,7 +46,7 @@ from app.generate_service_springboot.generate_service_springboot import (
 from app.generate_swagger.generate_swagger import (
     generate_swagger_config,
 )
-from app.model import ConvertRequest, DownloadRequest, Style
+from app.model import ConvertRequest, DownloadRequest, DuplicateChecker, Style
 from app.models.elements import (
     ClassObject,
     ModelsElements,
@@ -54,7 +54,6 @@ from app.models.elements import (
     UrlsElement,
     ViewsElements,
 )
-from app.models.methods import ClassMethodObject
 from app.parse_json_to_object_seq import ParseJsonToObjectSeq
 from app.utils import (
     is_valid_java_package_name,
@@ -78,7 +77,6 @@ instrumentator = Instrumentator().instrument(app)
 BASE_STATIC_TEMPLATES_DIR = os.path.join("app", "templates", "django_app")
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
 CSS_DIR = os.path.join(CUR_DIR, "templates", "css")
-DuplicateChecker = dict[tuple[str, str], ClassMethodObject]
 
 error_counter = Counter(
     "convert_errors_total", "Total number of errors by message", ["error_message"]

--- a/app/model.py
+++ b/app/model.py
@@ -2,7 +2,10 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from app.models.methods import ClassMethodObject
+
 Style = Literal["classic", "dark", "minimalist", "modern", "vibrant"]
+DuplicateChecker = dict[tuple[str, str], ClassMethodObject]
 
 
 class ConvertRequest(BaseModel):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,5 +3,5 @@ pytest >=8.3.4,<8.7.0
 pytest-cov >=6.0.0,<7.0.0
 cosmic-ray >=8.4.1,<9.0.0
 coverage >=7.6.12,<8.0.0
-pytest-asyncio
-pytest-bdd
+pytest-asyncio >=0.25.3,<0.30.0
+pytest-bdd >=8.1.0,<9.0.0

--- a/tests/integration/expected_app_properties.txt
+++ b/tests/integration/expected_app_properties.txt
@@ -1,0 +1,7 @@
+spring.datasource.driver-class-name=org.sqlite.JDBC
+springdoc.api-docs.enabled=true
+spring.datasource.url=jdbc:sqlite:mydatabase.db
+springdoc.swagger-ui.enabled=true
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update

--- a/tests/integration/test_integration_initialize_spring.py
+++ b/tests/integration/test_integration_initialize_spring.py
@@ -69,6 +69,7 @@ class TestIntegrationInitializeSpring(unittest.IsolatedAsyncioTestCase):
                     "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0",
                     buildf.read().decode("utf-8"),
                 )
+        os.remove(tmp_zip_path)
 
     async def test_application_properties_properly_filled(self):
         expected = ""
@@ -81,6 +82,7 @@ class TestIntegrationInitializeSpring(unittest.IsolatedAsyncioTestCase):
         with zipfile.ZipFile(tmp_zip_path) as zipf:
             with zipf.open("src/main/resources/application.properties") as f:
                 self.assertEqual(expected, f.read().decode("utf-8"))
+        os.remove(tmp_zip_path)
 
     async def test_no_duplicate_files(self):
         resp = client.post("/convert", json=self.json)

--- a/tests/integration/test_integration_initialize_spring.py
+++ b/tests/integration/test_integration_initialize_spring.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+import zipfile
+
+import anyio
+import requests
+from fastapi.testclient import TestClient
+
+from app.config import SPRING_SERVICE_URL
+from app.main import app, initialize_springboot_zip
+
+client = TestClient(app)
+CUR_DIR = os.path.dirname(os.path.realpath(__file__))
+test_diag = os.path.join(CUR_DIR, "..", "testdata", "BurhanpediaLite.class.jet")
+with open(test_diag) as f:
+    test_diag_content = f.read()
+
+
+class TestIntegrationInitializeSpring(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            "spring",
+            "-p",
+            "8080:8080",
+            "-e",
+            "HTTP_PROXY_PORT=9999",
+            "-d",
+            "mightyzanark/spring-initializr:1.0.2",
+        ]
+        subprocess.run(cmd)
+
+        max_attempts = 10
+        for _ in range(max_attempts):
+            try:
+                resp = requests.get(SPRING_SERVICE_URL, timeout=1)
+                if resp.status_code == 200:
+                    return
+            except (requests.RequestException, requests.ConnectionError):
+                time.sleep(1)
+
+        exit("Unable to start initializr")
+
+    @classmethod
+    def tearDownClass(cls):
+        subprocess.run(["docker", "stop", "spring"])
+
+    def setUp(self):
+        self.json = {
+            "filename": ["test_spring"],
+            "content": [[test_diag_content]],
+            "project_name": "spring",
+            "group_id": "com.motxt",
+            "project_type": "spring",
+        }
+
+    async def test_openapi_spring_mvc_in_build_gradle_has_version(self):
+        tmp_zip_path = await initialize_springboot_zip("any", "com.motxt")
+        with zipfile.ZipFile(tmp_zip_path) as zipf:
+            with zipf.open("build.gradle.kts") as buildf:
+                self.assertIn(
+                    "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0",
+                    buildf.read().decode("utf-8"),
+                )
+
+    async def test_application_properties_properly_filled(self):
+        expected = ""
+        async with await anyio.open_file(
+            os.path.join(CUR_DIR, "expected_app_properties.txt")
+        ) as f:
+            expected = await f.read()
+
+        tmp_zip_path = await initialize_springboot_zip("testapp", "com.motxt")
+        with zipfile.ZipFile(tmp_zip_path) as zipf:
+            with zipf.open("src/main/resources/application.properties") as f:
+                self.assertEqual(expected, f.read().decode("utf-8"))
+
+    async def test_no_duplicate_files(self):
+        resp = client.post("/convert", json=self.json)
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(resp.content)
+            temp.seek(0)
+            with zipfile.ZipFile(temp) as zipf:
+                namelist = zipf.namelist()
+                unique_names = set(namelist)
+                self.assertCountEqual(namelist, unique_names)

--- a/tests/springboot/test_generate_project.py
+++ b/tests/springboot/test_generate_project.py
@@ -4,6 +4,7 @@ import tempfile
 import zipfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 from pytest import fixture
 from pytest_bdd import given, scenarios, then, when
 
@@ -18,34 +19,30 @@ scenarios(FEATURE_PATH)
 
 
 @fixture
-def context():
+def context() -> dict:
     return {}
 
 
 @given("the parsed class diagram project name and group id")
-def prepare_context(context):
+def prepare_context(context: dict):
     asyncio.run(_prepare_context(context))
 
 
-async def _prepare_context(context):
-    with (
-        patch("httpx.AsyncClient") as mock_client_class,
-        patch("app.main.fix_build_gradle_kts") as mock_fix,
-    ):
+async def _prepare_context(context: dict):
+    with patch("httpx.AsyncClient") as mock_client_class:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {"content-type": "application/zip"}
-
-        mock_fix.return_value = ""
 
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_zip:
             with zipfile.ZipFile(tmp_zip.name, "w") as zipf:
                 zipf.writestr("src/main/java/", "")
                 zipf.writestr("src/test/java/", "")
                 zipf.writestr("build.gradle.kts", "")
+                zipf.writestr("src/main/resources/application.properties", "abcd=abcd")
 
-            with open(tmp_zip.name, "rb") as f:
-                mock_response.content = f.read()
+            async with await anyio.open_file(tmp_zip.name, "rb") as f:
+                mock_response.content = await f.read()
 
             context["mock_zip_path"] = tmp_zip.name
 
@@ -61,13 +58,15 @@ async def _prepare_context(context):
             "content": [
                 [
                     '{"diagram":"ClassDiagram","nodes":['
-                    '{"methods":"","name":"+ Shape","x":100,"y":70,"attributes":"+ colour: string","id":0,"type":"ClassNode"},'
-                    '{"methods":"+ getId (): string\\n+ setRadius (radius: integer): void","name":"+ Circle","x":320,"y":70,"attributes":"- radius: integer\\n- id: string","id":1,"type":"ClassNode"},'
-                    '{"methods":"+ findCircle(circleid: string): string","name":"+ Circles","x":190,"y":300,"attributes":"","id":2,"type":"ClassNode"}'
-                    '],"edges":['
-                    '{"Generalization Type":"Inheritance","start":1,"end":0,"type":"GeneralizationEdge"},'
+                    '{"methods":"","name":"+ Shape","x":100,"y":70,"attributes":"+ colour: string"'
+                    ',"id":0,"type":"ClassNode"},{"methods":"+ getId (): string\\n+ setRadius '
+                    '(radius: integer): void","name":"+ Circle","x":320,"y":70,"attributes":'
+                    '"- radius: integer\\n- id: string","id":1,"type":"ClassNode"},{"methods":'
+                    '"+ findCircle(circleid: string): string","name":"+ Circles","x":190,"y":'
+                    '300,"attributes":"","id":2,"type":"ClassNode"}],"edges":[{"Generalization '
+                    'Type":"Inheritance","start":1,"end":0,"type":"GeneralizationEdge"},'
                     '{"startLabel":"*","middleLabel":"","start":1,"directionality":"Unspecified","end":2,"endLabel":"1","type":"AssociationEdge"}'
-                    '],"version":"3.8"}\r\n'
+                    '],"version":"3.8"}'
                 ]
             ],
         }
@@ -86,7 +85,7 @@ async def _prepare_context(context):
 
 
 @when("the zip is unzip")
-def unzip_result(context):
+def unzip_result(context: dict):
     with zipfile.ZipFile(context["result_zip_path"], "r") as zip_ref:
         context["file_list"] = zip_ref.namelist()
         context["src_path"] = (
@@ -100,26 +99,26 @@ def unzip_result(context):
 
 
 @then("the zip contains model folder that consists of all models")
-def check_model_folder(context):
+def check_model_folder(context: dict):
     for model in ["Shape", "Circle", "Circles"]:
         assert f"{context['src_path']}/model/{model}.java" in context["file_list"]
 
 
 @then("the zip contains repository folder for all models")
-def check_repository_folder(context):
+def check_repository_folder(context: dict):
     print("aaaa", context["file_list"])
     for model in ["ShapeRepository", "CircleRepository", "CirclesRepository"]:
         assert f"{context['src_path']}/repository/{model}.java" in context["file_list"]
 
 
 @then("the zip contains service folder for all models")
-def check_service_folder(context):
+def check_service_folder(context: dict):
     for model in ["ShapeService", "CircleService", "CirclesService"]:
         assert f"{context['src_path']}/service/{model}.java" in context["file_list"]
 
 
 @then("the zip contains controller folder for all models")
-def check_controller_folder(context):
+def check_controller_folder(context: dict):
     for model in [
         "ShapeController",
         "CircleController",
@@ -130,12 +129,12 @@ def check_controller_folder(context):
 
 
 @then("the zip contains application.properties")
-def check_application_properties(context):
+def check_application_properties(context: dict):
     assert "src/main/resources/application.properties" in context["file_list"]
 
 
 @given("the context JSON with no diagram type")
-def prepare_invalid_jet_content(context):
+def prepare_invalid_jet_content(context: dict):
     context["data"] = {
         "project_name": "invalidProj",
         "group_id": "com.test",
@@ -143,45 +142,42 @@ def prepare_invalid_jet_content(context):
         "filename": ["Invalid_1.class.jet"],
         "content": [
             [
-                '{"nodes":['
-                '{"methods":"","name":"Shape","x":100,"y":70,"attributes":"+ colour: string","id":0,"type":"ClassNode"},'
-                '{"methods":"+ getId (): string\\n+ setRadius (radius: integer): void","name":"Circle","x":320,"y":70,"attributes":"- radius: integer\\n- id: string","id":1,"type":"ClassNode"},'
-                '{"methods":"+ findCircle(circleid: string): string","name":"Circles","x":190,"y":300,"attributes":"","id":2,"type":"ClassNode"}'
-                '],"edges":['
-                '{"Generalization Type":"Inheritance","start":1,"end":0,"type":"GeneralizationEdge"},'
-                '{"startLabel":"*","middleLabel":"","start":1,"directionality":"Unspecified","end":2,"endLabel":"1","type":"AssociationEdge"}'
-                '],"version":"3.8"}\r\n'
+                '{"nodes":[{"methods":"","name":"Shape","x":100,"y":70,"attributes":"+ colour: '
+                'string","id":0,"type":"ClassNode"},{"methods":"+ getId (): string\\n+ setRadius '
+                '(radius: integer): void","name":"Circle","x":320,"y":70,"attributes":"- radius: '
+                'integer\\n- id: string","id":1,"type":"ClassNode"},{"methods":"+ findCircle('
+                'circleid: string): string","name":"Circles","x":190,"y":300,"attributes":"",'
+                '"id":2,'
+                '"type":"ClassNode"}],"edges":[{"Generalization Type":"Inheritance",'
+                '"start":1,"end":0,"type":"GeneralizationEdge"},{"startLabel":"*","middleLabel":'
+                '"","start":1,"directionality":"Unspecified","end":2,"endLabel":"1","type":"AssociationEdge"}'
+                '],"version":"3.8"}'
             ]
         ],
     }
 
 
 @when("the content is parsed")
-def prepare_content(context):
+def prepare_content(context: dict):
     try:
         asyncio.run(call_convert_spring(context))
     except Exception as e:
         context["exception"] = e
 
 
-async def call_convert_spring(context):
-    with (
-        patch("httpx.AsyncClient") as mock_client_class,
-        patch("app.main.fix_build_gradle_kts") as mock_fix,
-    ):
+async def call_convert_spring(context: dict):
+    with patch("httpx.AsyncClient") as mock_client_class:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {"content-type": "application/zip"}
-
-        mock_fix.return_value = ""
 
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_zip:
             with zipfile.ZipFile(tmp_zip.name, "w") as zipf:
                 zipf.writestr("src/main/java/", "")
                 zipf.writestr("src/test/java/", "")
 
-            with open(tmp_zip.name, "rb") as f:
-                mock_response.content = f.read()
+            async with await anyio.open_file(tmp_zip.name, "rb") as f:
+                mock_response.content = await f.read()
 
             context["mock_zip_path"] = tmp_zip.name
 
@@ -215,14 +211,14 @@ async def call_convert_spring(context):
 
 
 @then("program will raise error for no diagram")
-def check_error(context):
+def check_error(context: dict):
     assert context["exception"] is not None, "Expected exception, but none was raised"
     assert isinstance(context["exception"], ValueError)
     assert str(context["exception"]) == "Diagram type not found on .jet file"
 
 
 @given("the context JSON with invalid diagram")
-def prepare_invalid_diagram(context):
+def prepare_invalid_diagram(context: dict):
     context["data2"] = {
         "project_name": "invalidProj",
         "group_id": "com.test",
@@ -230,12 +226,13 @@ def prepare_invalid_diagram(context):
         "filename": ["Invalid_1.class.jet"],
         "content": [
             [
-                '{"diagram":"SequenceDiagram","nodes":['
-                '{"methods":"","name":"Shape","x":100,"y":70,"attributes":"+ colour: string","id":0,"type":"ClassNode"},'
-                '{"methods":"+ getId (): string\\n+ setRadius (radius: integer): void","name":"Circle","x":320,"y":70,"attributes":"- radius: integer\\n- id: string","id":1,"type":"ClassNode"},'
-                '{"methods":"+ findCircle(circleid: string): string","name":"Circles","x":190,"y":300,"attributes":"","id":2,"type":"ClassNode"}'
-                '],"edges":['
-                '{"Generalization Type":"Inheritance","start":1,"end":0,"type":"GeneralizationEdge"},'
+                '{"diagram":"SequenceDiagram","nodes":[{"methods":"","name":"Shape","x":100,"y":70,'
+                '"attributes":"+ colour: string","id":0,"type":"ClassNode"},{"methods":'
+                '"+ getId (): string\\n+ setRadius (radius: integer): void","name":"Circle","x":'
+                '320,"y":70,"attributes":"- radius: integer\\n- id: string","id":1,"type":'
+                '"ClassNode"},{"methods":"+ findCircle(circleid: string): string","name":"Circles",'
+                '"x":190,"y":300,"attributes":"","id":2,"type":"ClassNode"}],"edges":[{"'
+                'Generalization Type":"Inheritance","start":1,"end":0,"type":"GeneralizationEdge"},'
                 '{"startLabel":"*","middleLabel":"","start":1,"directionality":"Unspecified","end":2,"endLabel":"1","type":"AssociationEdge"}'
                 '],"version":"3.8"}\r\n'
             ]
@@ -244,31 +241,26 @@ def prepare_invalid_diagram(context):
 
 
 @when("content is parsed")
-def prepare_content2(context):
+def prepare_content2(context: dict):
     try:
         asyncio.run(call_convert_spring2(context))
     except Exception as e:
         context["exception2"] = e
 
 
-async def call_convert_spring2(context):
-    with (
-        patch("httpx.AsyncClient") as mock_client_class,
-        patch("app.main.fix_build_gradle_kts") as mock_fix,
-    ):
+async def call_convert_spring2(context: dict):
+    with patch("httpx.AsyncClient") as mock_client_class:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {"content-type": "application/zip"}
-
-        mock_fix.return_value = ""
 
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_zip:
             with zipfile.ZipFile(tmp_zip.name, "w") as zipf:
                 zipf.writestr("src/main/java/", "")
                 zipf.writestr("src/test/java/", "")
 
-            with open(tmp_zip.name, "rb") as f:
-                mock_response.content = f.read()
+            async with await anyio.open_file(tmp_zip.name, "rb") as f:
+                mock_response.content = await f.read()
 
             context["mock_zip_path2"] = tmp_zip.name
 
@@ -299,13 +291,13 @@ async def call_convert_spring2(context):
 
 
 @then("program will raise error for invalid diagram")
-def check_error_2(context):
+def check_error_2(context: dict):
     assert context["exception2"] is not None, "Expected exception, but none was raised"
     assert isinstance(context["exception2"], ValueError)
     assert str(context["exception2"]) == "Given diagram is not Class Diagram"
 
 
-def cleanup(context):
+def cleanup(context: dict):
     if "result_zip_path" in context and os.path.exists(context["result_zip_path"]):
         os.unlink(context["result_zip_path"])
     if "mock_zip_path" in context and os.path.exists(context["mock_zip_path"]):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -535,9 +535,7 @@ def test_raise_value_error_on_main():
 async def test_convert_spring():
     with (
         patch("app.main.initialize_springboot_zip") as mock_zip,
-        patch("app.main.fix_build_gradle_kts") as mock_fix,
     ):
-        mock_fix.return_value = ""
         mock_zip.return_value = "a.zip"
         content = [
             [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import app, check_duplicate, convert_spring, fix_build_gradle_kts
+from app.main import app, check_duplicate, convert_spring
 from app.models.elements import ClassObject, ModelsElements
 from app.models.methods import ClassMethodObject
 
@@ -553,27 +553,3 @@ async def test_convert_spring():
         assert isinstance(response, str)
         assert os.path.isfile(response)
         os.remove(response)
-
-
-def test_fix_build_gradle_kts_with_patch():
-    # Mock the zipfile.ZipFile
-    mock_zipf = MagicMock()
-
-    # Mock reading the original build.gradle.kts content
-    original_content = (
-        'implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui")'
-    )
-    expected_content = (
-        'implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")'
-    )
-
-    # Mock zipf.open().read().decode()
-    mock_file = MagicMock()
-    mock_file.read.return_value = original_content.encode("utf-8")
-    mock_zipf.open.return_value = mock_file
-
-    # Call the function with the mocked zip
-    fix_build_gradle_kts(mock_zipf)
-
-    # Check that writestr is called with the correct modified content
-    mock_zipf.writestr.assert_called_once_with("build.gradle.kts", expected_content)


### PR DESCRIPTION
- Fixed duplicate files issues by writing them in Spring Initializr instead.
- Added some integration test code to make sure that Spring Initializr really writes what we wanted to the correct file. This test should not be run under normal circumstances. To ignore it, you can do `python -m pytest --ignore=tests/integration`, which will ignore all integration tests.
