### PR TITLE
EXTRA-6: Enhance Attribute Setter for Springboot for Multilevel Inheritance

### DIFF
--- a/app/generate_service_springboot/generate_service_springboot.py
+++ b/app/generate_service_springboot/generate_service_springboot.py
@@ -40,7 +40,12 @@ def get_all_attributes(model: ClassObject) -> list[str]:
 
     parent = model.get_parent()
 
+    accessed_parent = []
+
     while parent is not None:
+        if parent.get_name() in accessed_parent:
+            raise ValueError("Cyclic Inheritance detected! It should not be allowed!")
+        accessed_parent.append(parent.get_name())
         fields += parent.get_fields()
         parent = parent.get_parent()
 

--- a/app/generate_service_springboot/generate_service_springboot.py
+++ b/app/generate_service_springboot/generate_service_springboot.py
@@ -35,9 +35,14 @@ def generate_service_java(project_name: str, model: ClassObject, group_id: str) 
 def get_all_attributes(model: ClassObject) -> list[str]:
     attributes = []
 
-    fields = model.get_fields()
-    if model.get_parent() is not None:
-        fields += model.get_parent().get_fields()
+    fields = []
+    fields += model.get_fields()
+
+    parent = model.get_parent()
+
+    while parent is not None:
+        fields += parent.get_fields()
+        parent = parent.get_parent()
 
     for attribute in fields:
         attribute_name = attribute.get_name()

--- a/app/main.py
+++ b/app/main.py
@@ -270,23 +270,9 @@ async def convert_spring(
         zipf.writestr("run.bat", windows_runner, compress_type=zipfile.ZIP_DEFLATED)
         zipf.writestr("run.sh", linux_runner, compress_type=zipfile.ZIP_DEFLATED)
 
-        writer_models = ModelsElements("models.py")
+        data = fetch_data(filenames, contents)
 
-        classes = []
-        for file_name, content in zip(filenames, contents):
-            json_content = json.loads(content[0])
-            diagram_type = json_content.get("diagram", None)
-
-            if diagram_type is None:
-                raise ValueError("Diagram type not found on .jet file")
-
-            if diagram_type == "ClassDiagram":
-                with parse_latency.labels(diagram="UML class").time():
-                    classes = writer_models.parse(json_content, bidirectional=True)
-
-                    process_parsed_class(classes, duplicate_class_method_checker)
-            else:
-                raise ValueError("Given diagram is not Class Diagram")
+        writer_models = data["model_element"]
 
         model_files = writer_models.print_springboot_style(project_name, group_id)
 

--- a/app/main.py
+++ b/app/main.py
@@ -249,10 +249,6 @@ async def convert_spring(
 
     tmp_zip_path = await initialize_springboot_zip(project_name, group_id)
 
-    with zipfile.ZipFile(tmp_zip_path, "a", zipfile.ZIP_DEFLATED) as zipf:
-        # Section to Parse the Class Diagram
-        duplicate_class_method_checker: DuplicateChecker = {}
-
     src_path = group_id.replace(".", "/") + "/" + project_name
 
     with zipfile.ZipFile(tmp_zip_path, "a") as zipf:

--- a/tests/springboot/test_generate_project.py
+++ b/tests/springboot/test_generate_project.py
@@ -226,7 +226,7 @@ def prepare_invalid_diagram(context: dict):
         "filename": ["Invalid_1.class.jet"],
         "content": [
             [
-                '{"diagram":"SequenceDiagram","nodes":[{"methods":"","name":"Shape","x":100,"y":70,'
+                '{"diagram":"Diagram","nodes":[{"methods":"","name":"Shape","x":100,"y":70,'
                 '"attributes":"+ colour: string","id":0,"type":"ClassNode"},{"methods":'
                 '"+ getId (): string\\n+ setRadius (radius: integer): void","name":"Circle","x":'
                 '320,"y":70,"attributes":"- radius: integer\\n- id: string","id":1,"type":'
@@ -294,7 +294,7 @@ async def call_convert_spring2(context: dict):
 def check_error_2(context: dict):
     assert context["exception2"] is not None, "Expected exception, but none was raised"
     assert isinstance(context["exception2"], ValueError)
-    assert str(context["exception2"]) == "Given diagram is not Class Diagram"
+    assert str(context["exception2"]) == "Unknown diagram type. Diagram type must be ClassDiagram or SequenceDiagram"
 
 
 def cleanup(context: dict):

--- a/tests/springboot/test_generate_service.py
+++ b/tests/springboot/test_generate_service.py
@@ -58,6 +58,47 @@ class TestGenerateService(unittest.TestCase):
             expected_output.replace(" ", "").replace("\n", "").strip(),
         )
 
+    def test_multilevel_inheritance(self):
+        class_object_parent = ClassObject()
+        class_object_parent.set_name("AbstractUser")
+        field = FieldObject()
+        field_type = TypeObject()
+        field.set_name("id")
+        field_type.set_name("string")
+        field.set_type(field_type)
+        class_object_parent.add_field(field)
+
+        class_object = ClassObject()
+        class_object.set_name("User")
+        class_object.set_parent(class_object_parent)
+
+        project_name = "burhanpedia"
+
+        field = FieldObject()
+        field_type = TypeObject()
+        field.set_name("email")
+        field_type.set_name("string")
+        field.set_type(field_type)
+        class_object.add_field(field)
+
+        parent = ClassObject()
+        parent.set_name("Pembeli")
+        field = FieldObject()
+        field_type = TypeObject()
+        field.set_name("username")
+        field_type.set_name("string")
+        field.set_type(field_type)
+        parent.add_field(field)
+        parent.set_parent(class_object)
+        parent.set_is_public(True)
+
+        output = generate_service_java(project_name, parent, "com.example")
+
+        assert "existingPembeli.setId(pembeli.getId())" in output  # Level: AsbtractUser
+        assert "existingPembeli.setEmail(pembeli.getEmail())" in output  # Level: User
+        assert (
+            "existingPembeli.setUsername(pembeli.getUsername())" in output
+        )  # Level: Pembeli
 
 
 # Behavior Test
@@ -105,7 +146,7 @@ def render_template_output(context):
 def check_output(context):
     with open("tests/springboot/test_service_data.txt", "r", encoding="utf-8") as file:
         expected_output = file.read()
-    
+
     assert "setFull(cart.isFull())" in expected_output
     assert "setCartId(cart.getCartId())" in expected_output
 

--- a/tests/springboot/test_generate_service.py
+++ b/tests/springboot/test_generate_service.py
@@ -99,6 +99,30 @@ class TestGenerateService(unittest.TestCase):
         assert (
             "existingPembeli.setUsername(pembeli.getUsername())" in output
         )  # Level: Pembeli
+    
+    def test_edge_multilevel_cyclic_inheritance(self):
+        class_a = ClassObject()
+        class_a.set_name("TestA")
+
+        class_b = ClassObject()
+        class_b.set_name("TestB")
+
+        class_c = ClassObject()
+        class_c.set_name("TestC")
+
+        class_a.set_parent(class_b)
+        class_b.set_parent(class_c)
+        class_c.set_parent(class_a)
+
+        with self.assertRaises(ValueError) as ctx:
+            generate_service_java("TestInvalid", class_a, "com.example")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Cyclic Inheritance detected! It should not be allowed!"
+        )
+
+
 
 
 # Behavior Test


### PR DESCRIPTION
Now, generated edit endpoint for Springboot can support multilevel inheritance, especially for the setter and getter.

Case Study:
Let's say that there is a class called VipPembeli that inherits from Pembeli. Then Pembeli inherits from User, so that the inheritance is like
User -> Pembeli -> VipPembeli

Before:
The setter and getter will only get attributes for Pembeli and VipPembeli

Now:
The setter and getter will get all attributes from User, Pembeli, and VipPembeli