### PR TITLE
remove is_python_identifier check for parsing return value name for sequence diagram (for now)

### DIFF
--- a/app/parse_json_to_object_seq.py
+++ b/app/parse_json_to_object_seq.py
@@ -440,12 +440,6 @@ please consult the user manual document on how to name parameters"
         return_vars = []
         for edge in (e for e in self.__edges if e["type"] == "ReturnEdge"):
             label = edge["label"].strip()
-            if not is_valid_python_identifier(label):
-                raise ValueError(
-                    f"Return edge label must be a valid variable name! Given '{edge['label']}' \n\
-on sequence diagram please consult the user manual document on how to name methods"
-                )
-
             call_tuple = (edge["end"], edge["start"])
             if call_tuple not in self.__method_call:
                 raise ValueError(

--- a/tests/test_parse_misc.py
+++ b/tests/test_parse_misc.py
@@ -20,21 +20,6 @@ class TestParseMisc(unittest.TestCase):
             self.assertEqual(result[3], "hasTanggunganResult")
             self.assertEqual(result[4], "hasTanggunganResult")
 
-    def test_parse_return_edge_label_invalid(self):
-        with open("tests/testdata/parse_misc_negative1.json") as file:
-            json_data = file.read().replace("\n", "")
-            self.parser.set_json(json_data)
-            self.parser.parse()
-
-            with self.assertRaises(ValueError) as context:
-                self.parser.parse_return_edge()
-            self.assertEqual(
-                str(context.exception),
-                "Return edge label must be a valid variable name! Given '@return' \n"
-                "on sequence diagram please consult the "
-                "user manual document on how to name methods",
-            )
-
     def test_parse_return_edge_no_call_edge(self):
         with open("tests/testdata/parse_misc_negative2.json") as file:
             json_data = file.read().replace("\n", "")


### PR DESCRIPTION
remove is_python_identifier check for parsing return value name for sequence diagram (for video purposes)