### PR TITLE
Validation when integrating return var type in sequence parsing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -336,14 +336,17 @@ def check_duplicate(
             duplicate_class_method_checker[key] = class_method_object
         else:
             raise ValueError(
-                f"Cannot call class '{class_object_name}' objects not defined in Class Diagram!"
+                f"Cannot call method '{class_method_object.get_name()}' of "
+                f"class '{class_object_name}'! The method or class is not defined in Class Diagram!"
             )
     return duplicate_class_method_checker
 
 
 def create_django_project(project_name: str, zipfile_path: str) -> list[str]:
     if not is_valid_python_identifier(project_name):
-        raise ValueError("Project name must not contain whitespace or number!")
+        raise ValueError(
+            f"Project name must not contain whitespace or number! Got: '{project_name}'"
+        )
 
     # write django project template to a dictionary
     files = render_project_django_template(
@@ -361,9 +364,11 @@ def create_django_project(project_name: str, zipfile_path: str) -> list[str]:
 
 def validate_django_app(project_name: str, app_name: str, zipfile_path: str):
     if not is_valid_python_identifier(app_name):
-        raise ValueError("App name must not contain whitespace!")
+        raise ValueError(f"App name must not contain whitespace! Got: '{app_name}'")
     if not is_valid_python_identifier(project_name):
-        raise ValueError("Project name must not contain whitespace!")
+        raise ValueError(
+            f"Project name must not contain whitespace! Got: '{project_name}'"
+        )
     if not os.path.exists(zipfile_path):
         raise FileNotFoundError(f"File {zipfile_path} does not exist")
 
@@ -584,7 +589,8 @@ def fetch_data(filenames: list[str], contents: list[list[str]]) -> dict[str]:
 
         else:
             raise ValueError(
-                "Unknown diagram type. Diagram type must be ClassDiagram or SequenceDiagram"
+                "Unknown diagram type. Diagram type must be ClassDiagram or SequenceDiagram! "
+                f"Got '{diagram_type}'"
             )
 
     for class_method_object in duplicate_class_method_checker.values():

--- a/app/parse_json_to_object_seq.py
+++ b/app/parse_json_to_object_seq.py
@@ -452,8 +452,14 @@ please consult the user manual document on how to name parameters"
                 and method_call_info["method_call"]
             ):
                 ret_var_name, ret_var_type = self.process_return_variable(label)
-                method_call_info["method_call"].set_ret_var(ret_var_name)
-                method_call_info["method_call"].set_return_var_type(ret_var_type)
-                return_vars.append(ret_var_name)
-
+                if ret_var_name and ret_var_type:
+                    method_call_info["method_call"].set_ret_var(ret_var_name)
+                    method_call_info["method_call"].set_return_var_type(ret_var_type)
+                    return_vars.append(ret_var_name)
+                else:
+                    raise ValueError(
+                        "Return value name or return value type not set when "
+                        f"calling {method_call_info['method_call'].get_name()} "
+                        "in Sequence Diagram!"
+                    )
         return return_vars

--- a/tests/springboot/test_generate_project.py
+++ b/tests/springboot/test_generate_project.py
@@ -294,7 +294,10 @@ async def call_convert_spring2(context: dict):
 def check_error_2(context: dict):
     assert context["exception2"] is not None, "Expected exception, but none was raised"
     assert isinstance(context["exception2"], ValueError)
-    assert str(context["exception2"]) == "Unknown diagram type. Diagram type must be ClassDiagram or SequenceDiagram"
+    assert str(context["exception2"]) == (
+        "Unknown diagram type. Diagram type must be "
+        "ClassDiagram or SequenceDiagram! Got 'Diagram'"
+    )
 
 
 def cleanup(context: dict):

--- a/tests/test_generate_downloadable.py
+++ b/tests/test_generate_downloadable.py
@@ -354,5 +354,8 @@ class TestGenerateFileToBeDownloadedPublic(unittest.TestCase):
 
         self.assertEqual(
             str(ctx.exception),
-            "Unknown diagram type. Diagram type must be ClassDiagram or SequenceDiagram",
+            (
+                "Unknown diagram type. Diagram type must be ClassDiagram or SequenceDiagram! "
+                "Got 'ActivityDiagram'"
+            ),
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -442,7 +442,8 @@ def test_check_duplicate_no_matching_method():
     duplicate_class_method_checker = {"hello": ClassObject()}
     with pytest.raises(
         ValueError,
-        match="Cannot call class 'class1' objects not defined in Class Diagram!",
+        match="Cannot call method 'method1' of class 'class1'! The method or class is not defined "
+        "in Class Diagram!",
     ):
         check_duplicate(
             class_objects, class_object.get_name(), duplicate_class_method_checker
@@ -509,7 +510,8 @@ def test_check_duplicate_empty_duplicate_class_method_checker():
 
     with pytest.raises(
         ValueError,
-        match="Cannot call class 'class1' objects not defined in Class Diagram!",
+        match="Cannot call method 'method1' of class 'class1'! The method or class is "
+        "not defined in Class Diagram!",
     ):
         check_duplicate(
             class_objects, class_object.get_name(), duplicate_class_method_checker

--- a/tests/test_render_project_django.py
+++ b/tests/test_render_project_django.py
@@ -72,7 +72,7 @@ class TestGenerateDjangoProjectTemplate(unittest.TestCase):
             create_django_project("test project", self.tmp_zip.name)
         self.assertEqual(
             str(context.exception),
-            "Project name must not contain whitespace or number!",
+            "Project name must not contain whitespace or number! Got: 'test project'",
         )
         if os.path.exists("project_test_project"):
             shutil.rmtree("project_test_project")
@@ -154,7 +154,7 @@ class TestGenerateDjangoMain(unittest.TestCase):
             create_django_app("test_main", "buku pin", self.tmp_zip.name)
         self.assertEqual(
             str(context.exception),
-            "App name must not contain whitespace!",
+            "App name must not contain whitespace! Got: 'buku pin'",
         )
 
     def test_generate_django_app_negative_invalid_project_name(self):
@@ -162,7 +162,7 @@ class TestGenerateDjangoMain(unittest.TestCase):
             create_django_app("test main", "main", self.tmp_zip.name)
         self.assertEqual(
             str(context.exception),
-            "Project name must not contain whitespace!",
+            "Project name must not contain whitespace! Got: 'test main'",
         )
 
     def test_generate_django_app_negative_zip_not_exist(self):


### PR DESCRIPTION
I've added a couple of validations when parsing return variable type for method calls in sequence diagram. I've also changed some of the error messages in main.py to be more specific and descriptive.