### PR TITLE
feat: make urls.py and requirements.txt write directly to zip

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -153,7 +153,6 @@ async def convert(
 async def convert_django(
     project_name: str, filenames: list[str], contents: list[list[str]], style: Style
 ) -> str:
-    first_fname = filenames[0]
     tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     tmp_zip_path = tmp_zip.name
     try:
@@ -200,8 +199,6 @@ async def convert_django(
             f"{project_name}_views.py",
             os.path.join("app", "requirements.txt"),
             os.path.join("app", "urls.py"),
-            f"{first_fname}_models.py",
-            f"{first_fname}_views.py",
         ]
         for file in files:
             if os.path.exists(file):

--- a/app/main.py
+++ b/app/main.py
@@ -47,7 +47,13 @@ from app.generate_service_springboot.generate_service_springboot import (
 from app.generate_swagger.generate_swagger import (
     generate_swagger_config,
 )
-from app.model import ConvertRequest, DownloadRequest, DuplicateChecker, Style
+from app.model import (
+    ConvertRequest,
+    DataResult,
+    DownloadRequest,
+    DuplicateChecker,
+    Style,
+)
 from app.models.elements import (
     ClassObject,
     ModelsElements,
@@ -252,20 +258,19 @@ async def convert_spring(
 
     src_path = group_id.replace(".", "/") + "/" + project_name
 
-    with zipfile.ZipFile(tmp_zip_path, "a") as zipf:
+    with zipfile.ZipFile(tmp_zip_path, "a", zipfile.ZIP_DEFLATED) as zipf:
         # put swagger config to zip
         swagger_config_content = generate_swagger_config(group_id, project_name)
         zipf.writestr(
             write_springboot_path(src_path, "config", "Swagger"),
             swagger_config_content,
-            compress_type=zipfile.ZIP_DEFLATED,
         )
 
         # put runner to zip
         windows_runner = generate_springboot_window_runner()
         linux_runner = generate_springboot_linux_runner()
-        zipf.writestr("run.bat", windows_runner, compress_type=zipfile.ZIP_DEFLATED)
-        zipf.writestr("run.sh", linux_runner, compress_type=zipfile.ZIP_DEFLATED)
+        zipf.writestr("run.bat", windows_runner)
+        zipf.writestr("run.sh", linux_runner)
 
         data = fetch_data(filenames, contents)
 
@@ -537,7 +542,7 @@ def process_parsed_class(
             duplicate_checker[(model_class.get_name(), method.get_name())] = method
 
 
-def fetch_data(filenames: list[str], contents: list[list[str]]) -> dict[str]:
+def fetch_data(filenames: list[str], contents: list[list[str]]) -> DataResult:
     """
     This is the logic from convert() method to process the requested
     files. To use this method, pass the request.filename and request.content

--- a/app/main.py
+++ b/app/main.py
@@ -196,8 +196,6 @@ async def convert_django(
         files = [
             f"{project_name}_models.py",
             f"{project_name}_views.py",
-            os.path.join("app", "requirements.txt"),
-            os.path.join("app", "urls.py"),
         ]
         for file in files:
             if os.path.exists(file):
@@ -498,7 +496,7 @@ def process_parsed_class(
             duplicate_checker[(model_class.get_name(), method.get_name())] = method
 
 
-def fetch_data(filenames: list[str], contents: list[list[str]]) -> DataResult:
+def fetch_data(_filenames: list[str], contents: list[list[str]]) -> DataResult:
     """
     This is the logic from convert() method to process the requested
     files. To use this method, pass the request.filename and request.content
@@ -512,7 +510,7 @@ def fetch_data(filenames: list[str], contents: list[list[str]]) -> DataResult:
     writer_views = ViewsElements("views.py")
 
     classes = []
-    for file_name, content in zip(filenames, contents):
+    for content in contents:
         json_content = json.loads(content[0])
         diagram_type = json_content.get("diagram", None)
 

--- a/app/model.py
+++ b/app/model.py
@@ -1,11 +1,19 @@
-from typing import Literal, Optional
+from typing import Literal, Optional, TypedDict
 
 from pydantic import BaseModel, Field
 
+from app.models.elements import ModelsElements, ViewsElements
 from app.models.methods import ClassMethodObject
 
 Style = Literal["classic", "dark", "minimalist", "modern", "vibrant"]
 DuplicateChecker = dict[tuple[str, str], ClassMethodObject]
+
+
+class DataResult(TypedDict):
+    models: str
+    views: str
+    model_element: ModelsElements
+    views_element: ViewsElements
 
 
 class ConvertRequest(BaseModel):

--- a/app/models/elements.py
+++ b/app/models/elements.py
@@ -42,7 +42,7 @@ class FileElements(ABC):
 
         async with await anyio.open_file(file, "w") as f:
             await f.write(to_be_print)
-        print("done writing", file)
+
         return file
 
 

--- a/app/models/elements.py
+++ b/app/models/elements.py
@@ -36,7 +36,7 @@ class FileElements(ABC):
     def print_django_style(self) -> str:  # pragma: no cover
         pass
 
-    async def write_to_file(self, path: str) -> None:
+    async def write_to_file(self, path: str) -> str:
         file = path + "/" + self.__name
         to_be_print = self.print_django_style()
 

--- a/app/templates/models.py.j2
+++ b/app/templates/models.py.j2
@@ -4,14 +4,12 @@ checkout more about us on https://motxt.ppl.cs.ui.ac.id
 """
 
 from django.db import models
+{% for class in classes %}
 
-
-{% for class in classes -%}
 class {{ class.name }}({{ class.parent }}):
-    {% for field in class.fields -%}
+{%- for field in class.fields %}
     {{ field.name }} = {{ field.type }}
-    {% else -%}{#- this else block only happens if fields is empty -#}
+{%- else %}
     pass
-    {%- endfor %}
-
+{%- endfor %}
 {% endfor -%}

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -106,7 +106,6 @@ class TestModelsElements(unittest.TestCase):
         self.assertEqual(classes[1].get_name(), "DuplicateClass")
 
     def test_composition_one_to_many(self):
-        self.maxDiff = None
         data = ""
         with open(os.path.join(TEST_DIR, "test_composition1.json")) as f:
             data = f.read()
@@ -121,7 +120,6 @@ class TestModelsElements(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_composition_many_to_one(self):
-        self.maxDiff = None
         data = ""
         with open(os.path.join(TEST_DIR, "test_composition2.json")) as f:
             data = f.read()
@@ -178,7 +176,6 @@ class TestModelsElements(unittest.TestCase):
         self.assertEqual(res, expected)
 
     def test_aggregation_one_to_one_template(self):
-        self.maxDiff = None
         data = ""
         with open(os.path.join(TEST_DIR, "test_aggregation1.json")) as f:
             data = f.read()

--- a/tests/test_generate_downloadable.py
+++ b/tests/test_generate_downloadable.py
@@ -24,8 +24,8 @@ class TestGenerateFileToBeDownloadedPrivate(unittest.TestCase):
         self.filename = json_data["filename"]
         self.content = json_data["content"]
         data = fetch_data(self.filename, self.content)
-        writer_requirements = RequirementsElements("requirements.txt")
-        writer_urls = UrlsElement("urls.py")
+        writer_requirements = RequirementsElements()
+        writer_urls = UrlsElement()
         # simulate the creation of requirements.txt and urls.py instead of using write_to_file()
         with open(os.path.join(os.getcwd(), "app", "requirements.txt"), "w") as f:
             f.write(writer_requirements.print_django_style())
@@ -33,6 +33,7 @@ class TestGenerateFileToBeDownloadedPrivate(unittest.TestCase):
         self.models_content = data["models"]
         self.views_content = data["views"]
         self.writer_models = data["model_element"]
+        self.file_elements = (self.writer_models, writer_requirements, writer_urls)
         self.project_name = self.filename[0]
         writer_urls.set_classes(self.writer_models.get_classes())
         with open(os.path.join(os.getcwd(), "app", "urls.py"), "w") as f:
@@ -62,7 +63,7 @@ class TestGenerateFileToBeDownloadedPrivate(unittest.TestCase):
             self.project_name,
             self.models_content,
             self.views_content,
-            self.writer_models,
+            self.file_elements,
             self.tmp_zip.name,
         )
 
@@ -96,37 +97,37 @@ class TestGenerateFileToBeDownloadedPrivate(unittest.TestCase):
             for file in zipf.namelist():
                 self.assertIn(file, expected_output)
 
-    def test_generate_file_to_be_downloaded_without_requirements(self):
+    def test_generate_file_to_be_downloaded_without_writing_requirements_to_disk(self):
         if os.path.exists(os.path.join(os.getcwd(), "app", "requirements.txt")):
             os.remove(os.path.join(os.getcwd(), "app", "requirements.txt"))
-        with self.assertRaises(FileNotFoundError) as ctx:
-            generate_file_to_be_downloaded(
-                self.project_name,
-                self.models_content,
-                self.views_content,
-                self.writer_models,
-                self.tmp_zip.name,
-            )
-        self.assertEqual(
-            str(ctx.exception),
-            "File requirements.txt does not exist",
+
+        result = generate_file_to_be_downloaded(
+            self.project_name,
+            self.models_content,
+            self.views_content,
+            self.file_elements,
+            self.tmp_zip.name,
         )
 
-    def test_generate_file_to_be_downloaded_without_urls(self):
+        self.assertIn("requirements.txt", result)
+        with zipfile.ZipFile(self.tmp_zip.name, "r") as zipf:
+            self.assertIn("requirements.txt", zipf.namelist())
+
+    def test_generate_file_to_be_downloaded_without_writing_urls_to_disk(self):
         if os.path.exists(os.path.join(os.getcwd(), "app", "urls.py")):
             os.remove(os.path.join(os.getcwd(), "app", "urls.py"))
-        with self.assertRaises(FileNotFoundError) as ctx:
-            generate_file_to_be_downloaded(
-                self.project_name,
-                self.models_content,
-                self.views_content,
-                self.writer_models,
-                self.tmp_zip.name,
-            )
-        self.assertEqual(
-            str(ctx.exception),
-            "File urls.py does not exist",
+
+        result = generate_file_to_be_downloaded(
+            self.project_name,
+            self.models_content,
+            self.views_content,
+            self.file_elements,
+            self.tmp_zip.name,
         )
+
+        self.assertIn("main/urls.py", result)
+        with zipfile.ZipFile(self.tmp_zip.name, "r") as zipf:
+            self.assertIn("main/urls.py", zipf.namelist())
 
     def test_generate_file_to_be_downloaded_multiple_calls(self):
         """
@@ -139,7 +140,7 @@ class TestGenerateFileToBeDownloadedPrivate(unittest.TestCase):
             self.project_name,
             self.models_content,
             self.views_content,
-            self.writer_models,
+            self.file_elements,
             tmp_zipfile.name,
         )
         self.assertTrue(os.path.exists(tmp_zipfile.name))
@@ -153,7 +154,7 @@ class TestGenerateFileToBeDownloadedPrivate(unittest.TestCase):
             self.project_name,
             self.models_content,
             self.views_content,
-            self.writer_models,
+            self.file_elements,
             self.tmp_zip.name,
         )
         self.assertTrue(os.path.exists(self.tmp_zip.name))
@@ -178,8 +179,8 @@ class TestGenerateFileToBeDownloadedPublic(unittest.TestCase):
         self.content = json_data["content"]
         self.project_name = json_data["project_name"]
         data = fetch_data(self.filename, self.content)
-        writer_requirements = RequirementsElements("requirements.txt")
-        writer_urls = UrlsElement("urls.py")
+        writer_requirements = RequirementsElements()
+        writer_urls = UrlsElement()
         # simulate the creation of requirements.txt and urls.py instead of using write_to_file()
         with open(os.path.join(os.getcwd(), "app", "requirements.txt"), "w") as f:
             f.write(writer_requirements.print_django_style())
@@ -187,6 +188,7 @@ class TestGenerateFileToBeDownloadedPublic(unittest.TestCase):
         self.models_content = data["models"]
         self.views_content = data["views"]
         self.writer_models = data["model_element"]
+        self.file_elements = (self.writer_models, writer_requirements, writer_urls)
         writer_urls.set_classes(self.writer_models.get_classes())
         with open(os.path.join(os.getcwd(), "app", "urls.py"), "w") as f:
             f.write(writer_urls.print_django_style())
@@ -227,7 +229,7 @@ class TestGenerateFileToBeDownloadedPublic(unittest.TestCase):
                 invalid_project_name,
                 self.models_content,
                 self.views_content,
-                self.writer_models,
+                self.file_elements,
                 self.tmp_zip.name,
             )
         self.assertIn(
@@ -244,7 +246,7 @@ class TestGenerateFileToBeDownloadedPublic(unittest.TestCase):
             self.project_name,
             self.models_content,
             self.views_content,
-            self.writer_models,
+            self.file_elements,
             self.tmp_zip.name,
         )
         expected_files = [
@@ -296,7 +298,7 @@ class TestGenerateFileToBeDownloadedPublic(unittest.TestCase):
             self.project_name,
             self.models_content,
             self.views_content,
-            self.writer_models,
+            self.file_elements,
             self.tmp_zip.name,
         )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,7 @@ def test_file() -> dict:
 
 
 def test_file_already_exists():
+    """This should now be successfull"""
     with open("file1_models.py", "w") as f:
         f.write("Some initial content")
 
@@ -65,8 +66,7 @@ def test_file_already_exists():
                     "project_name": "file1",
                 },
             )
-            assert response.status_code == 400
-            assert response.json()["detail"] == "Please try again later"
+            assert response.status_code == 200
     finally:
         # Clean up: remove the file created for the test
         if os.path.exists("file1_models.py"):
@@ -74,6 +74,7 @@ def test_file_already_exists():
 
 
 def test_slash_on_filename():
+    """This should now be successfull as we don't need to check the given filenames"""
     # Try to upload a file
     with (
         patch("app.main.ModelsElements") as mockparser,
@@ -104,8 +105,7 @@ def test_slash_on_filename():
                 "project_name": "file1",
             },
         )
-        assert response.status_code == 400
-        assert response.json()["detail"] == "/ not allowed in file name"
+        assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,6 +148,7 @@ async def test_convert_endpoint_valid_content_class_diagram():
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
         assert "file1.zip" in response.headers["content-disposition"]
+        assert response.content[8:10] == b"\x08\x00"  # Compression method = DEFLATE
 
 
 @pytest.mark.asyncio
@@ -211,6 +212,7 @@ async def test_convert_endpoint_class_diagram():
         assert response.content.startswith(
             b"PK\x03\x04"
         )  # Check that the response is a zip file
+        assert response.content[8:10] == b"\x08\x00"  # Compression method = DEFLATE
 
 
 @pytest.mark.asyncio
@@ -273,6 +275,7 @@ async def test_convert_endpoint_sequence_diagram():
         assert response.content.startswith(
             b"PK\x03\x04"
         )  # Check that the response is a zip file
+        assert response.content[8:10] == b"\x08\x00"  # Compression method = DEFLATE
 
 
 @pytest.mark.asyncio
@@ -361,6 +364,7 @@ async def test_convert_endpoint_valid_sequence_diagram():
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
         assert "file1.zip" in response.headers["content-disposition"]
+        assert response.content[8:10] == b"\x08\x00"
 
 
 @pytest.mark.asyncio
@@ -398,6 +402,7 @@ async def test_convert_endpoint_valid_multiple_file_content():
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/zip"
         assert "file1.zip" in response.headers["content-disposition"]
+        assert response.content[8:10] == b"\x08\x00"
 
 
 @pytest.mark.asyncio

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,8 @@
 import pytest
 from pydantic import ValidationError
 
-from app.main import ConvertRequest, DownloadRequest
+from app.main import ConvertRequest
+from app.model import DownloadRequest
 
 
 def test_valid_download_request():

--- a/tests/testdata/test_aggregation_result_template1.txt
+++ b/tests/testdata/test_aggregation_result_template1.txt
@@ -11,7 +11,7 @@ class Buku(models.Model):
     judul = models.CharField(max_length=255)
     penulis = models.CharField(max_length=255)
     penerbit = models.CharField(max_length=255)
-    
+
 
 class Peminjaman(models.Model):
     ID = models.CharField(max_length=255)
@@ -20,7 +20,7 @@ class Peminjaman(models.Model):
     tglKembali = models.DateField()
     isLunasDenda = models.BooleanField()
     besaranDenda = models.IntegerField()
-    
+
 
 class CopyBuku(models.Model):
     kodeBarcode = models.CharField(max_length=255)
@@ -30,5 +30,3 @@ class CopyBuku(models.Model):
     edisi = models.IntegerField()
     tahunTerbit = models.IntegerField()
     buku = models.OneToOneField('Buku', on_delete=models.SET_NULL, null=True)
-    
-

--- a/tests/testdata/test_aggregation_result_template2.txt
+++ b/tests/testdata/test_aggregation_result_template2.txt
@@ -11,7 +11,7 @@ class Buku(models.Model):
     judul = models.CharField(max_length=255)
     penulis = models.CharField(max_length=255)
     penerbit = models.CharField(max_length=255)
-    
+
 
 class Peminjaman(models.Model):
     ID = models.CharField(max_length=255)
@@ -20,7 +20,7 @@ class Peminjaman(models.Model):
     tglKembali = models.DateField()
     isLunasDenda = models.BooleanField()
     besaranDenda = models.IntegerField()
-    
+
 
 class CopyBuku(models.Model):
     kodeBarcode = models.CharField(max_length=255)
@@ -30,5 +30,3 @@ class CopyBuku(models.Model):
     edisi = models.IntegerField()
     tahunTerbit = models.IntegerField()
     bukuFK = models.ForeignKey('Buku', on_delete=models.SET_NULL, null=True)
-    
-

--- a/tests/testdata/test_composition_result_template1.txt
+++ b/tests/testdata/test_composition_result_template1.txt
@@ -11,7 +11,7 @@ class Buku(models.Model):
     judul = models.CharField(max_length=255)
     penulis = models.CharField(max_length=255)
     penerbit = models.CharField(max_length=255)
-    
+
 
 class Peminjaman(models.Model):
     ID = models.CharField(max_length=255)
@@ -20,7 +20,7 @@ class Peminjaman(models.Model):
     tglKembali = models.DateField()
     isLunasDenda = models.BooleanField()
     besaranDenda = models.IntegerField()
-    
+
 
 class CopyBuku(models.Model):
     kodeBarcode = models.CharField(max_length=255)
@@ -30,5 +30,3 @@ class CopyBuku(models.Model):
     edisi = models.IntegerField()
     tahunTerbit = models.IntegerField()
     bukuFK = models.ForeignKey('Buku', on_delete=models.CASCADE)
-    
-

--- a/tests/testdata/test_composition_result_template2.txt
+++ b/tests/testdata/test_composition_result_template2.txt
@@ -12,7 +12,7 @@ class Buku(models.Model):
     penulis = models.CharField(max_length=255)
     penerbit = models.CharField(max_length=255)
     copybukuFK = models.ForeignKey('CopyBuku', on_delete=models.CASCADE)
-    
+
 
 class Peminjaman(models.Model):
     ID = models.CharField(max_length=255)
@@ -21,7 +21,7 @@ class Peminjaman(models.Model):
     tglKembali = models.DateField()
     isLunasDenda = models.BooleanField()
     besaranDenda = models.IntegerField()
-    
+
 
 class CopyBuku(models.Model):
     kodeBarcode = models.CharField(max_length=255)
@@ -30,5 +30,3 @@ class CopyBuku(models.Model):
     isAvailable = models.BooleanField()
     edisi = models.IntegerField()
     tahunTerbit = models.IntegerField()
-    
-

--- a/tests/testdata/test_composition_result_template3.txt
+++ b/tests/testdata/test_composition_result_template3.txt
@@ -11,7 +11,7 @@ class Buku(models.Model):
     judul = models.CharField(max_length=255)
     penulis = models.CharField(max_length=255)
     penerbit = models.CharField(max_length=255)
-    
+
 
 class Peminjaman(models.Model):
     ID = models.CharField(max_length=255)
@@ -20,7 +20,7 @@ class Peminjaman(models.Model):
     tglKembali = models.DateField()
     isLunasDenda = models.BooleanField()
     besaranDenda = models.IntegerField()
-    
+
 
 class CopyBuku(models.Model):
     kodeBarcode = models.CharField(max_length=255)
@@ -30,5 +30,3 @@ class CopyBuku(models.Model):
     edisi = models.IntegerField()
     tahunTerbit = models.IntegerField()
     buku = models.OneToOneField('Buku', on_delete=models.CASCADE)
-    
-


### PR DESCRIPTION
This PR only have some slight changes and nothing new as it is only making the writing of `urls.py` and `requirements.txt` straight to the zip file instead of having to write it to the disk first. I have also deleted the `download_file` function as that does not seem to really be used anymore. For all the zip files I have also made it so that the contents are written in DEFLATE mode, so the files are actually compressed and not just plain text in the zip.