### PR TITLE
Pbi 12 4 handle composition in springboot project generation

### DIFF
--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -303,9 +303,8 @@ class ManyToOneRelationshipObject(AbstractRelationshipObject):
                 )
                 onetomany_params.append("orphanRemoval = true")
 
-            rel_type = (
-                f"@OneToMany(\n\t\t{',\n\t\t'.join(onetomany_params)}\n)\n\t@JsonIgnore"
-            )
+            params_str = ",\n\t\t".join(onetomany_params)
+            rel_type = f"@OneToMany(\n\t\t{params_str}\n)\n\t@JsonIgnore"
             # FK in target table referencing source
             join = f'@JoinColumn(name = "{source.replace(" ", "_")}_id")'
             var = f"private List<{to_pascal_case(target)}> {to_camel_case(target)}s;"
@@ -356,6 +355,7 @@ class ManyToManyRelationshipObject(AbstractRelationshipObject):
         param.append(
             f'inverseJoinColumns = @JoinColumn(name = "{target.replace(" ", "_").lower()}_id")'
         )
-        join = f"@JoinTable(\n\t\t{',\n\t\t'.join(param)}\n\t)"
+        params_str = ",\n\t\t".join(param)
+        join = f"@JoinTable(\n\t\t{params_str}\n\t)"
         var = f"private List<{to_pascal_case(target)}> listOf{to_pascal_case(target)}s;"
         return {"name": var, "type": rel_type, "join": join}

--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -339,7 +339,8 @@ class ManyToManyRelationshipObject(AbstractRelationshipObject):
                 "cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}"
             )
             params.append("orphanRemoval = true\n")
-            rel_type = f"@ManyToMany(\n\t\t{',\n\t\t'.join(params)})\n\t@JsonIgnore"
+            params_str = ",\n\t\t".join(params)
+            rel_type = f"@ManyToMany(\n\t\t{params_str})\n\t@JsonIgnore"
         else:
             rel_type = (
                 "@ManyToMany("

--- a/app/models/diagram.py
+++ b/app/models/diagram.py
@@ -236,12 +236,11 @@ class OneToOneRelationshipObject(AbstractRelationshipObject):
                 else "{CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}"
             )
             orphan = (
-                ", orphanRemoval = false"
+                "orphanRemoval = false"
                 if self.get_type() == RelationshipType.AGGREGATION
-                else ""
+                else "orphanRemoval = true"
             )
-
-            rel_type = rel_type = f"@OneToOne(cascade = {cascade_values}{orphan})"
+            rel_type = f"@OneToOne(\n\t\tcascade = {cascade_values},\n\t\t{orphan}\n)"
             join = f'@JoinColumn(name = "{source.replace(" ", "_")}_id")'
         var = f"private {to_pascal_case(target)} {to_camel_case(target)};"
         return {"name": var, "type": rel_type, "join": join}
@@ -285,17 +284,29 @@ class ManyToOneRelationshipObject(AbstractRelationshipObject):
     def to_springboot_models_template(self) -> dict[str, str]:
         source = self.get_source_class().get_name().lower()
         target = self.get_target_class().get_name()
+
         if self.get_source_class_own_amount() == "1":
             rel_type = f'@ManyToOne(mappedBy="{source.replace(" ", "_")}_id")'
             rel_type += f'\n\t@JsonIgnoreProperties("{source.replace(" ", "_")}s")'
             join = None
             var = f"private {to_pascal_case(target)} {to_camel_case(target)};"
         else:
+            onetomany_params = []
+            if self.get_type() == RelationshipType.AGGREGATION:
+                onetomany_params.append(
+                    "cascade = {CascadeType.PERSIST, CascadeType.MERGE}"
+                )
+                onetomany_params.append("orphanRemoval = false")
+            elif self.get_type() == RelationshipType.COMPOSITION:
+                onetomany_params.append(
+                    "cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}"
+                )
+                onetomany_params.append("orphanRemoval = true")
+
             rel_type = (
-                "@OneToMany(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE},"
+                f"@OneToMany(\n\t\t{',\n\t\t'.join(onetomany_params)}\n)\n\t@JsonIgnore"
             )
-            rel_type += "\n\t\torphanRemoval = true\n)"
-            rel_type += "\n\t@JsonIgnore"
+            # FK in target table referencing source
             join = f'@JoinColumn(name = "{source.replace(" ", "_")}_id")'
             var = f"private List<{to_pascal_case(target)}> {to_camel_case(target)}s;"
         return {"name": var, "type": rel_type, "join": join}
@@ -322,16 +333,29 @@ class ManyToManyRelationshipObject(AbstractRelationshipObject):
     def to_springboot_models_template(self) -> dict[str, str]:
         source = self.get_source_class().get_name().lower()
         target = self.get_target_class().get_name()
-        rel_type = "@ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})"
-        rel_type += "\n\t@JsonIgnore"
-        join = "@JoinTable("
-        join += f'\n\t\tname = "{source.replace(" ", "_")}_{target.replace(" ", "_").lower()}",'
-        join += (
-            f'\n\t\tjoinColumns = @JoinColumn(name = "{source.replace(" ", "_")}_id"),'
+        params = []
+
+        if self.get_type() == RelationshipType.COMPOSITION:
+            params.append(
+                "cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}"
+            )
+            params.append("orphanRemoval = true\n")
+            rel_type = f"@ManyToMany(\n\t\t{',\n\t\t'.join(params)})\n\t@JsonIgnore"
+        else:
+            rel_type = (
+                "@ManyToMany("
+                "cascade = {CascadeType.PERSIST, CascadeType.MERGE})\n\t@JsonIgnore"
+            )
+        param = []
+        param.append(
+            f'name = "{source.replace(" ", "_")}_{target.replace(" ", "_").lower()}"'
         )
-        join += (
-            f"\n\t\tinverseJoinColumns = @JoinColumn("
-            f'name = "{target.replace(" ", "_").lower()}_id")\n\t)'
+        param.append(
+            f'joinColumns = @JoinColumn(name = "{source.replace(" ", "_")}_id")'
         )
+        param.append(
+            f'inverseJoinColumns = @JoinColumn(name = "{target.replace(" ", "_").lower()}_id")'
+        )
+        join = f"@JoinTable(\n\t\t{',\n\t\t'.join(param)}\n\t)"
         var = f"private List<{to_pascal_case(target)}> listOf{to_pascal_case(target)}s;"
         return {"name": var, "type": rel_type, "join": join}

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -514,6 +514,27 @@ class TestToSpringbootModelsTemplate(unittest.TestCase):
         }
         self.assertEqual(relationship.to_springboot_models_template(), expected_output)
 
+    def test_many_to_many_relationship_composition(self):
+        relationship = ManyToManyRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        relationship.set_type(RelationshipType.COMPOSITION)
+        relationship.set_source_class_own_amount("1")
+        expected_output = {
+            "name": "private List<TargetClass> listOfTargetClasss;",
+            "type": (
+                "@ManyToMany(\n\t\t"
+                "cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},\n\t\t"
+                "orphanRemoval = true\n)\n\t"
+                "@JsonIgnore"
+            ),
+            "join": "@JoinTable("
+            '\n\t\tname = "source_class_target_class",'
+            '\n\t\tjoinColumns = @JoinColumn(name = "source_class_id"),'
+            '\n\t\tinverseJoinColumns = @JoinColumn(name = "target_class_id")\n\t)',
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
     def test_one_to_one_relationship_edge_case_empty_names(self):
         self.source_class.set_name("")
         self.target_class.set_name("")

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -431,22 +431,24 @@ class TestToSpringbootModelsTemplate(unittest.TestCase):
         relationship.set_source_class_own_amount("1+")
         expected_output = {
             "name": "private TargetClass targetClass;",
-            "type": "@OneToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, "
-            "orphanRemoval = false)",
+            "type": "@OneToOne(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE},\n\t\t"
+            "orphanRemoval = false\n)",
             "join": '@JoinColumn(name = "source_class_id")',
         }
         self.assertEqual(relationship.to_springboot_models_template(), expected_output)
 
-    def test_one_to_one_relationship_positive_2(self):
+    def test_one_to_one_relationship_composition(self):
         relationship = OneToOneRelationshipObject()
         relationship.set_source_class(self.source_class)
         relationship.set_target_class(self.target_class)
+        relationship.set_type(RelationshipType.COMPOSITION)
         relationship.set_source_class_own_amount("1+")
         expected_output = {
             "name": "private TargetClass targetClass;",
             "type": (
-                "@OneToOne(cascade = {CascadeType.PERSIST, "
-                "CascadeType.MERGE, CascadeType.REMOVE})"
+                "@OneToOne(\n\t\tcascade = {CascadeType.PERSIST, "
+                "CascadeType.MERGE, CascadeType.REMOVE}"
+                ",\n\t\torphanRemoval = true\n)"
             ),
             "join": '@JoinColumn(name = "source_class_id")',
         }

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -469,11 +469,29 @@ class TestToSpringbootModelsTemplate(unittest.TestCase):
         relationship = ManyToOneRelationshipObject()
         relationship.set_source_class(self.source_class)
         relationship.set_target_class(self.target_class)
+        relationship.set_type(RelationshipType.AGGREGATION)
         relationship.set_source_class_own_amount("*")
         expected_output = {
             "name": "private List<TargetClass> targetClasss;",
             "type": "@OneToMany(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE},\n\t\t"
-            "orphanRemoval = true\n)\n\t@JsonIgnore",
+            "orphanRemoval = false\n)\n\t@JsonIgnore",
+            "join": '@JoinColumn(name = "source_class_id")',
+        }
+        self.assertEqual(relationship.to_springboot_models_template(), expected_output)
+
+    def test_many_to_one_relationship_composition(self):
+        relationship = ManyToOneRelationshipObject()
+        relationship.set_source_class(self.source_class)
+        relationship.set_target_class(self.target_class)
+        relationship.set_type(RelationshipType.COMPOSITION)
+        relationship.set_source_class_own_amount("*")
+        expected_output = {
+            "name": "private List<TargetClass> targetClasss;",
+            "type": (
+                "@OneToMany(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE"
+                ", CascadeType.REMOVE},\n\t\t"
+                "orphanRemoval = true\n)\n\t@JsonIgnore"
+            ),
             "join": '@JoinColumn(name = "source_class_id")',
         }
         self.assertEqual(relationship.to_springboot_models_template(), expected_output)

--- a/tests/test_parse_class_pattern/test_strategy.py
+++ b/tests/test_parse_class_pattern/test_strategy.py
@@ -228,8 +228,8 @@ class TestRelationshipStrategyBidirectional(unittest.TestCase):
             {
                 "join": '@JoinColumn(name = "_id")',
                 "name": "private  ;",
-                "type": "@OneToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, "
-                "CascadeType.REMOVE})",
+                "type": "@OneToOne(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE, "
+                "CascadeType.REMOVE},\n\t\torphanRemoval = true\n)",
             },
         )
         self.assertEqual(
@@ -279,6 +279,40 @@ class TestRelationshipStrategyBidirectional(unittest.TestCase):
 
         strategy.create_relationship(
             edge, class_from, class_to, RelationshipType.ASSOCIATION, bidirectional=True
+        )
+        self.assertEqual(len(class_from._ClassObject__relationships), 1)
+        self.assertEqual(
+            class_from._ClassObject__relationships[0].get_target_class(), class_to
+        )
+        self.assertEqual(
+            class_to._ClassObject__relationships[0].get_target_class(), class_from
+        )
+
+    def test_many_to_many_bidirectional_aggregation(self):
+        strategy = ManyToManyStrategy()
+        edge = {"startLabel": "*", "endLabel": "*"}
+        class_from = ClassObject()
+        class_to = ClassObject()
+
+        strategy.create_relationship(
+            edge, class_from, class_to, RelationshipType.AGGREGATION, bidirectional=True
+        )
+        self.assertEqual(len(class_from._ClassObject__relationships), 1)
+        self.assertEqual(
+            class_from._ClassObject__relationships[0].get_target_class(), class_to
+        )
+        self.assertEqual(
+            class_to._ClassObject__relationships[0].get_target_class(), class_from
+        )
+
+    def test_many_to_many_bidirectional_composition(self):
+        strategy = ManyToOneStrategy()
+        edge = {"startLabel": "*", "endLabel": "1"}
+        class_from = ClassObject()
+        class_to = ClassObject()
+
+        strategy.create_relationship(
+            edge, class_from, class_to, RelationshipType.COMPOSITION, bidirectional=True
         )
         self.assertEqual(len(class_from._ClassObject__relationships), 1)
         self.assertEqual(

--- a/tests/test_parse_class_pattern/test_strategy.py
+++ b/tests/test_parse_class_pattern/test_strategy.py
@@ -228,8 +228,8 @@ class TestRelationshipStrategyBidirectional(unittest.TestCase):
             {
                 "join": '@JoinColumn(name = "_id")',
                 "name": "private  ;",
-                "type": "@OneToOne(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE, "
-                "CascadeType.REMOVE},\n\t\torphanRemoval = true\n)",
+                "type": "@OneToOne(\n\t\tcascade = {CascadeType.PERSIST, CascadeType.MERGE},"
+                "\n\t\torphanRemoval = true\n)",
             },
         )
         self.assertEqual(


### PR DESCRIPTION
This pull request introduces enhancements to relationship modeling in the `diagram` and `parse_relationship_strategy` modules, with a focus on supporting relationship type `COMPOSITION` and bidirectional relationships. Additionally, new test cases have been added to ensure the correctness of these changes. This pull request has @KenKomKom's commits because it has implementation i needed to work on mine. Below are the most important changes grouped by theme:

### Enhancements to Relationship Modeling
* Updated `to_springboot_models_template` and `to_models_code_template` methods in `app/models/diagram.py` to dynamically handle `cascade` and `orphanRemoval` attributes based on the relationship type (`AGGREGATION` or `COMPOSITION`). This ensures proper mapping for `@OneToOne`, `@OneToMany`, and `@ManyToMany` annotations. [[1]](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680L233-R243) [[2]](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680R287-R309) [[3]](diffhunk://#diff-78a5dbdff924e53b14761a27cb0224e46629026c314fecfdec45199126ed0680L317-R359)
* Refactored `_relation_obj_setter_helper` in `app/parse_class_pattern/parse_relationship_strategy.py` to rename the `type` parameter to `relation_type` for clarity and added support for bidirectional relationships by creating a reverse relationship object. [[1]](diffhunk://#diff-b5b1ba6ae42514a43bcdc43ecb1dcfaec50c9e56c7e47ac22e7cc3789545114bL16-R19) [[2]](diffhunk://#diff-b5b1ba6ae42514a43bcdc43ecb1dcfaec50c9e56c7e47ac22e7cc3789545114bR32-R42) [[3]](diffhunk://#diff-b5b1ba6ae42514a43bcdc43ecb1dcfaec50c9e56c7e47ac22e7cc3789545114bR51-R53)

### Test Coverage Improvements
* Added new test cases in `tests/test_diagram.py` to validate the behavior of `to_springboot_models_template` for `COMPOSITION` relationship types across `@OneToOne`, `@OneToMany` ,`@ManyToOne`, and `@ManyToMany` annotations. [[1]](diffhunk://#diff-53c4826ad5ed4307b804c033bc147f28c124d509798b5edad005021e55f0f030L426-R451) [[2]](diffhunk://#diff-53c4826ad5ed4307b804c033bc147f28c124d509798b5edad005021e55f0f030R474-R496) [[3]](diffhunk://#diff-53c4826ad5ed4307b804c033bc147f28c124d509798b5edad005021e55f0f030R519-R539)
* Introduced tests in `tests/test_parse_class_pattern/test_strategy.py` to verify bidirectional relationship handling  `COMPOSITION` in `OneToOne` ,`ManyToOne`,`OneToMany`, and `ManyToMany` strategies. [[1]](diffhunk://#diff-45d4f19e23561106ecda9792f3b63a9fc7d105120d85c136fe0bc245000b6677R208-R239) [[2]](diffhunk://#diff-45d4f19e23561106ecda9792f3b63a9fc7d105120d85c136fe0bc245000b6677R291-R324)